### PR TITLE
Feature/scaffold project view

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "eslintConfig": {
     "root": true,
     "env": {
-      "node": true
+      "node": true,
+      "vue/setup-compiler-macros": true
     },
     "extends": [
       "plugin:vue/vue3-essential",

--- a/src/components/project_view_components/ProjectImages.vue
+++ b/src/components/project_view_components/ProjectImages.vue
@@ -1,0 +1,10 @@
+<script setup>
+</script>
+<template>
+    <v-card>
+        <div>TODO image format toggle</div>
+        <div>TODO Archive Image List</div>
+        <div>or</div>
+        <div>TODO Table Image List</div>
+    </v-card>
+</template>

--- a/src/components/project_view_components/ProjectImages.vue
+++ b/src/components/project_view_components/ProjectImages.vue
@@ -1,11 +1,11 @@
 <script setup>
     // this prop should be enough to know which project to fetch images from
-    const props = defineProps(['selectedProject'])
+    defineProps(['selectedProject'])
 </script>
 <template>
     <v-card>
         <!-- These divs are just for demonstration purposes, feel free to remove them when implemented -->
-        <div>{{ props.selectedProject }}</div>
+        <div>{{ selectedProject }}</div>
         <div>under construction: Image format toggle</div>
         <div>under construction: Image Carousel or Archive List</div>
     </v-card>

--- a/src/components/project_view_components/ProjectImages.vue
+++ b/src/components/project_view_components/ProjectImages.vue
@@ -1,10 +1,12 @@
 <script setup>
+    // this prop should be enough to know which project to fetch images from
+    const props = defineProps(['selectedProject'])
 </script>
 <template>
     <v-card>
-        <div>TODO image format toggle</div>
-        <div>TODO Archive Image List</div>
-        <div>or</div>
-        <div>TODO Table Image List</div>
+        <!-- These divs are just for demonstration purposes, feel free to remove them when implemented -->
+        <div>{{ props.selectedProject }}</div>
+        <div>under construction: Image format toggle</div>
+        <div>under construction: Image Carousel or Archive List</div>
     </v-card>
 </template>

--- a/src/components/project_view_components/ProjectList.vue
+++ b/src/components/project_view_components/ProjectList.vue
@@ -18,12 +18,12 @@
 <template>
     <v-container class="d-lg-flex">
         <!-- component for list of user's projects -->
-        <v-card class="h-auto pa-6 ma-1" title="Projects">
+        <v-card class="h-auto w-25 pa-6 ma-1" title="Projects">
             <v-expansion-panels variant="accordion">
                 <ProjectSelector v-for='(project, index) in projects' :key="index" :project="project" @click="selectedProject = project.projectTitle"/>
             </v-expansion-panels>
         </v-card>
         <!-- component for display of project's images for selection and creation of new data sessions-->
-        <project-images class="h-auto pa-6 ma-1" :selectedProject="selectedProject"/>
+        <project-images class="h-auto w-75 pa-6 ma-1" :selectedProject="selectedProject"/>
     </v-container>
 </template>

--- a/src/components/project_view_components/ProjectList.vue
+++ b/src/components/project_view_components/ProjectList.vue
@@ -1,34 +1,29 @@
 <script setup>
+    import { ref } from 'vue'
     import ProjectImages from './ProjectImages.vue';
     import ProjectSelector from './ProjectSelector.vue';
 
     // TODO replace projects with an api call to the users projects
-    const projects = [
-        { projectTitle: 'project 1', projectDate: '2019', projectDescription: 'a study of the stars'},
-        { projectTitle: 'project 2', projectDate: '2019', projectDescription: 'a study of the stars'},
-        { projectTitle: 'project 3', projectDate: '2019', projectDescription: 'a study of the stars'},
-        { projectTitle: 'project 4', projectDate: '2019', projectDescription: 'a study of the stars'},
-        { projectTitle: 'project 5', projectDate: '2019', projectDescription: 'a study of the stars'},
-    ]
-    // TODO bind this to be equal to the ProjectSelector the user has clicked on
-    const selectedProject = 1
+    const projects = ref([
+        { projectTitle: 'project 1', projectDescription: 'things like site code, date, image id, etc can go in here'},
+        { projectTitle: 'project 2', projectDescription: 'things like site code, date, image id, etc can go in here'},
+        { projectTitle: 'project 3', projectDescription: 'things like site code, date, image id, etc can go in here'},
+        { projectTitle: 'project 4', projectDescription: 'things like site code, date, image id, etc can go in here'},
+        { projectTitle: 'project 5', projectDescription: 'things like site code, date, image id, etc can go in here'},
+    ])
+    // Reactive id of the project whose images should be on display
+    let selectedProject = ref('no project selected')
 </script>
 
 <template>
-    <v-container>
-        <v-row>
-            <v-col>
-                <v-card class="h-100 pa-6 ma-1" title="Projects">
-                    <v-expansion-panels>
-                        <!-- TODO depending on the index/project selected a prop should be passed to project-images indicating which project is selected -->
-                        <ProjectSelector v-for='(project, index) in projects' :key="index" :project="project"/>
-                    </v-expansion-panels>
-                </v-card>
-            </v-col>
-            <v-col>
-                <project-images class="h-100 pa-6 ma-1" :selectedProject="selectedProject">
-                </project-images>
-            </v-col>
-        </v-row>
+    <v-container class="d-lg-flex">
+        <!-- component for list of user's projects -->
+        <v-card class="h-auto pa-6 ma-1" title="Projects">
+            <v-expansion-panels variant="accordion">
+                <ProjectSelector v-for='(project, index) in projects' :key="index" :project="project" @click="selectedProject = project.projectTitle"/>
+            </v-expansion-panels>
+        </v-card>
+        <!-- component for display of project's images for selection and creation of new data sessions-->
+        <project-images class="h-auto pa-6 ma-1" :selectedProject="selectedProject"/>
     </v-container>
 </template>

--- a/src/components/project_view_components/ProjectList.vue
+++ b/src/components/project_view_components/ProjectList.vue
@@ -1,0 +1,34 @@
+<script setup>
+    import ProjectImages from './ProjectImages.vue';
+    import ProjectSelector from './ProjectSelector.vue';
+
+    // TODO replace projects with an api call to the users projects
+    const projects = [
+        { projectTitle: 'project 1', projectDate: '2019', projectDescription: 'a study of the stars'},
+        { projectTitle: 'project 2', projectDate: '2019', projectDescription: 'a study of the stars'},
+        { projectTitle: 'project 3', projectDate: '2019', projectDescription: 'a study of the stars'},
+        { projectTitle: 'project 4', projectDate: '2019', projectDescription: 'a study of the stars'},
+        { projectTitle: 'project 5', projectDate: '2019', projectDescription: 'a study of the stars'},
+    ]
+    // TODO bind this to be equal to the ProjectSelector the user has clicked on
+    const selectedProject = 1
+</script>
+
+<template>
+    <v-container>
+        <v-row>
+            <v-col>
+                <v-card class="h-100 pa-6 ma-1" title="Projects">
+                    <v-expansion-panels>
+                        <!-- TODO depending on the index/project selected a prop should be passed to project-images indicating which project is selected -->
+                        <ProjectSelector v-for='(project, index) in projects' :key="index" :project="project"/>
+                    </v-expansion-panels>
+                </v-card>
+            </v-col>
+            <v-col>
+                <project-images class="h-100 pa-6 ma-1" :selectedProject="selectedProject">
+                </project-images>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>

--- a/src/components/project_view_components/ProjectSelector.vue
+++ b/src/components/project_view_components/ProjectSelector.vue
@@ -1,0 +1,9 @@
+<script setup>
+ const props = defineProps(['project'])
+</script>
+<template>
+    <v-expansion-panel
+        :title = "props.project.projectTitle"
+        :text = "props.project.projectDescription"
+    ></v-expansion-panel>
+</template>

--- a/src/components/project_view_components/ProjectSelector.vue
+++ b/src/components/project_view_components/ProjectSelector.vue
@@ -1,9 +1,9 @@
 <script setup>
- const props = defineProps(['project'])
+ defineProps(['project'])
 </script>
 <template>
     <v-expansion-panel
-        :title = "props.project.projectTitle"
-        :text = "props.project.projectDescription"
+        :title = "project.projectTitle"
+        :text = "project.projectDescription"
     ></v-expansion-panel>
 </template>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -3,5 +3,5 @@
 </script>
 
 <template>
-    <project-list/>
+    <project-list class="h-screen"/>
 </template>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -1,7 +1,7 @@
 <script setup>
-    import SelectedImage from '../components/SelectedImage.vue'
+    import ProjectList from '../components/project_view_components/ProjectList.vue'
 </script>
 
 <template>
-    <SelectedImage/>
+    <project-list/>
 </template>


### PR DESCRIPTION
This PR adds in some components that will be the foundation for additions to the Project View page. These components are the ProjectList, Project Selector, and ProjectImages

Changes: 
- add vue macros to eslint config to hide warnings
- ProjectImages component with prop selectedProject
- ProjectList component with some fake data and the Selectors/Images
- ProjectSelector which allows the user to select a project to view and see details
- ProjectView the base window for the page

<img width="1157" alt="Screenshot 2023-12-11 at 3 20 30 PM" src="https://github.com/LCOGT/datalab-ui/assets/54085254/600bab5f-73b6-48eb-9c4a-2ab8b613d959">
