### PR TITLE
Feature/datasession-image-display

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -44,7 +44,6 @@ const getImages = async () => {
     }
 
     const data = await response.json()
-    console.log(data)
     images.value = data.results
     .flatMap(img => img.input_data)
     // Filtering out items with 'archive' in the source

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -71,7 +71,7 @@ onMounted(() => {
           <v-carousel-item
             v-for="(image, index) in images"
             :key="index"
-            :src="require('../assets/' + image)"
+            :src="image ? require('../assets/' + image) : ''"
             cover
           ></v-carousel-item>
         </v-carousel>

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -3,7 +3,7 @@ import { ref, onMounted } from 'vue'
 import OperationPipeline from './OperationPipeline.vue';
 
 const emit = defineEmits(['reloadSession'])
-const images = ref([])
+let images = ref([])
 
 const props = defineProps({
   data: {
@@ -29,7 +29,7 @@ function addOperation(operationDefinition) {
 
 const getImages = async () => {
   try {
-    const response = await fetch ('http://127.0.0.1:8000/api/datasessions/', {
+    const response = await fetch ('http://127.0.0.1:8000/api/datasessions/' + props.data.id, {
       method: 'GET',
       headers: {
         'Authorization': 'Token 123456789abcdefg',
@@ -44,11 +44,9 @@ const getImages = async () => {
     }
 
     const data = await response.json()
-    images.value = data.results
-    .flatMap(img => img.input_data)
-    // Filtering out items with 'archive' in the source
-    .filter(src => !src.source.includes('archive'))
-    .map(src => src.source)
+    images.value = data.input_data
+      .filter(img => !img.source.includes('archive'))
+      .map(img => img.source)
   } catch (error) {
     console.log('Error getting images: ', error)
   }


### PR DESCRIPTION
## FEATURE: Display of images on DataSession View

### DESCRIPTION


**Background:**
We need to display the `selectedImages` in the DataSession View that were POSTed to the api by clicking the `Add to Session` button in the Project View so that users can perform image operations on their images.


**Implementation:**
There's a new `ref` in the component `DataSession` and I named it `images` and initialized it to be an empty array. 
In `getImages()` I make a `GET` request to the mock api and assign the response (specifically, `data.results`) to the value of `images` to access these in the template and display them as images. I filter out any ones whose `source` includes the word "archive" because those won't display an image. 
To display the images, I loop through the `images` array in a `for...in` loop in the template. Then I require them from the `assets` local folder and the files are each of the `images`. The screenshots below will help convey my message.

**Important Note:**
Currently, when the user navigates to a different session (clicks on a separate tab), the first image to load is black. I'm not sure why this is, but I did add a conditional rendering to make sure that if there aren't any images to display, then don't display anything. 
Another important note is that all of the images from the api are being displayed for each data session rather than only the images associated with that session. Trying to find a workaround, but likely, the workaround will be that we need to implement functionality for which session we want to add selectedImages to.


### VISUALS
**Console: response data, screen: no first image**
<img width="1728" alt="Screenshot 2024-01-08 at 3 14 43 PM" src="https://github.com/LCOGT/datalab-ui/assets/54489472/5b4b04e5-e9a0-47dc-b2e7-1e88c4631fc9">

**Video of image carousel in DataSession view**
https://github.com/LCOGT/datalab-ui/assets/54489472/7deb4c35-e359-4658-b2db-f3492e46a3ea

