### PR TITLE
Implemented Image List such that it uses store

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "parserOptions": {
       "parser": "@babel/eslint-parser"
     },
-    "rules": {}
+    "rules": {
+      "no-unused-vars": "off"
+    }
   },
   "browserslist": [
     "> 1%",

--- a/src/components/ProjectView/ImageList.vue
+++ b/src/components/ProjectView/ImageList.vue
@@ -19,16 +19,12 @@ let itemsPerPage = ref(15);
 let selected = ref([])
 
 // since item-value for v-data-table is set to basefilename we need to convert it back into an object
-// figuring out how to set item-value to the entire object would be great and then this function can be simplified
 function select(selectedImageNames) {
-  const selectedObjects = selectedImageNames.map(basefileName =>
-    items.value.find(item => item.basefile_name === basefileName)
-  );
-  store.dispatch('setSelectedImages', selectedObjects)
+  store.dispatch('setSelectedImages', selectedImageNames)
 }
 
 onMounted ( () => {
-  selected.value = store.getters.selectedImages.map(item => item.basefile_name)
+  selected.value = store.getters.selectedImages
 })
 </script>
 
@@ -36,13 +32,14 @@ onMounted ( () => {
   <v-data-table
     :headers="headers"
     :items="items"
-    :hover="true"
-    v-model:items-per-page="itemsPerPage"
+    item-value="basefile_name"
+    :return-object="true"
     show-select
     v-model="selected"
-    item-value="basefile_name"
-    density="compact"
     @update:modelValue="select($event)"
+    density="compact"
+    :hover="true"
+    v-model:items-per-page="itemsPerPage"
   >
     <!-- TODO change src to fetch image from url-->
     <template #[`item.image`]="{ item }">

--- a/src/components/ProjectView/ImageList.vue
+++ b/src/components/ProjectView/ImageList.vue
@@ -1,41 +1,46 @@
 <script setup>
-    import { ref } from 'vue'
-    const props = defineProps(['projectImageObjects', 'selectedImages', 'data'])
+import { ref } from "vue";
+import { useStore } from "vuex";
 
-    // v-data-table setup variables
-    let headers = ref([
-        { title: 'Image Name', align: 'start', sortable: true, key: 'basefile_name'},
-        { title: 'Time', align:'start', sortable: true, key: 'time'},
-        { title: 'Object', align:'start', sortable: true, key: 'object'},
-        { title: 'Image', align:'start', sortable: false, key: 'image'}
-    ])
-    let items = ref(props.data)
-    let itemsPerPage = ref(15)
-    let selected = ref([])
+const props = defineProps(["projectImageObjects", "selectedImages", "data"]);
+const store = useStore();
+
+// v-data-table setup variables
+let headers = ref([
+  { title: "Image Name", align: "start", sortable: true, key: "basefile_name" },
+  { title: "Time", align: "start", sortable: true, key: "time" },
+  { title: "Object", align: "start", sortable: true, key: "object" },
+  { title: "Image", align: "start", sortable: false, key: "image" },
+]);
+let items = ref(props.data);
+let itemsPerPage = ref(15);
+
+// selected images logic
+function selectRow(item) {
+  store.dispatch("toggleImageSelection", item);
+}
 </script>
 
 <template>
-    <v-data-table
-        :headers="headers"
-        :items="items"
-        v-model:items-per-page="itemsPerPage"
-        show-select
-        v-model="selected"
-        item-value="basefile_name"
-        density="compact"
-        @update:modelValue="$emit('updateSelected', selected)"
-    >
-        <!-- TODO change src to fetch image from url-->
-        <template #[`item.image`]="{ item }">
-            <v-img
-            :src="require('@/assets/' + item.image)"
-            :alt="item.basefile_name"
-            height="72"
-            width="128"
-            cover
-            >
-            </v-img>
-        </template>
-    </v-data-table>
-    
+  <v-data-table
+    :headers="headers"
+    :items="items"
+    @click="selectRow(item)"
+    v-model:items-per-page="itemsPerPage"
+    show-select
+    item-value="basefile_name"
+    density="compact"
+  >
+    <!-- TODO change src to fetch image from url-->
+    <template #[`item.image`]="{ item }">
+      <v-img
+        :src="require('@/assets/' + item.image)"
+        :alt="item.basefile_name"
+        height="72"
+        width="128"
+        cover
+      >
+      </v-img>
+    </template>
+  </v-data-table>
 </template>

--- a/src/components/ProjectView/ImageList.vue
+++ b/src/components/ProjectView/ImageList.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref } from "vue";
+import { ref, onMounted } from "vue";
 import { useStore } from "vuex";
 
-const props = defineProps(["projectImageObjects", "selectedImages", "data"]);
+const props = defineProps(["data"]);
 const store = useStore();
 
 // v-data-table setup variables
@@ -15,21 +15,34 @@ let headers = ref([
 let items = ref(props.data);
 let itemsPerPage = ref(15);
 
-// selected images logic
-function selectRow(item) {
-  store.dispatch("toggleImageSelection", item);
+// --- Selection Logic ---
+let selected = ref([])
+
+// since item-value for v-data-table is set to basefilename we need to convert it back into an object
+// figuring out how to set item-value to the entire object would be great and then this function can be simplified
+function select(selectedImageNames) {
+  const selectedObjects = selectedImageNames.map(basefileName =>
+    items.value.find(item => item.basefile_name === basefileName)
+  );
+  store.dispatch('setSelectedImages', selectedObjects)
 }
+
+onMounted ( () => {
+  selected.value = store.getters.selectedImages.map(item => item.basefile_name)
+})
 </script>
 
 <template>
   <v-data-table
     :headers="headers"
     :items="items"
-    @click="selectRow(item)"
+    :hover="true"
     v-model:items-per-page="itemsPerPage"
     show-select
+    v-model="selected"
     item-value="basefile_name"
     density="compact"
+    @update:modelValue="select($event)"
   >
     <!-- TODO change src to fetch image from url-->
     <template #[`item.image`]="{ item }">

--- a/src/components/ProjectView/ImageList.vue
+++ b/src/components/ProjectView/ImageList.vue
@@ -18,7 +18,6 @@ let itemsPerPage = ref(15);
 // --- Selection Logic ---
 let selected = ref([])
 
-// since item-value for v-data-table is set to basefilename we need to convert it back into an object
 function select(selectedImageNames) {
   store.dispatch('setSelectedImages', selectedImageNames)
 }

--- a/src/components/ProjectView/ProjectImages.vue
+++ b/src/components/ProjectView/ProjectImages.vue
@@ -1,21 +1,14 @@
 <script setup>
-    import { ref } from 'vue'
-    import ImageList from './ImageList.vue'
-    // TODO for now we will just import project data from mock data but in the future call an api based on selectedProject
-    import MockData from '../../assets/MockData.JSON'
+import ImageList from "./ImageList.vue";
+// TODO for now we will just import project data from mock data but in the future call an api based on selectedProject
+import MockData from "../../assets/MockData.JSON";
 
-    // functionality to switch between image layouts while retaining selected images
-    defineProps(['selectedProject'])
-
-    let selectedImages = ref([])
-
-    function updateSelectedImages(selected){
-        selectedImages.value = selected
-    }
+// functionality to switch between image layouts while retaining selected images
+defineProps(["selectedProject"]);
 </script>
 
 <template>
-        <!-- These divs are just for demonstration purposes, feel free to remove them when implemented -->
-    <div>{{ selectedProject }}</div>
-    <image-list :data="MockData" :selectedImages="selectedImages" @update-selected="updateSelectedImages"/>
+  <!-- These divs are just for demonstration purposes, feel free to remove them when implemented -->
+  <div>{{ selectedProject }}</div>
+  <image-list :data="MockData" />
 </template>

--- a/src/components/ProjectView/ProjectList.vue
+++ b/src/components/ProjectView/ProjectList.vue
@@ -1,20 +1,26 @@
 <script setup>
-import { ref } from 'vue'
-import ProjectImages from './ProjectImages.vue'
-import ProjectBar from './ProjectBar.vue'
+import { ref } from "vue";
+import ProjectImages from "./ProjectImages.vue";
+import ProjectBar from "./ProjectBar.vue";
 
-let selectedProject = ref('no project selected')
+let selectedProject = ref("no project selected");
 
 const handleProjectSelection = (projectTitle) => {
-    selectedProject.value = projectTitle
-}
+  selectedProject.value = projectTitle;
+};
 </script>
 
 <template>
-    <div class="project-bar-wrapper">
-        <ProjectBar @update:selectedProject="handleProjectSelection" class="project-bar"/>
-        <ProjectImages class="h-auto w-75 pa-6 ma-1 project-images" :selectedProject="selectedProject"/>
-    </div>
+  <div class="project-bar-wrapper">
+    <ProjectBar
+      @update:selectedProject="handleProjectSelection"
+      class="project-bar"
+    />
+    <ProjectImages
+      class="h-auto w-75 pa-6 ma-1 project-images"
+      :selectedProject="selectedProject"
+    />
+  </div>
 </template>
 
 <style scoped>
@@ -24,13 +30,13 @@ const handleProjectSelection = (projectTitle) => {
   justify-content: space-between;
 }
 .project-bar {
-    width: 26%;
-    margin: 0;
-    padding: 2%
+  width: 26%;
+  margin: 0;
+  padding: 2%;
 }
 .project-images {
-    width: 70%;
-    margin: 0;
-    padding: 0;
+  width: 70%;
+  margin: 0;
+  padding: 0;
 }
 </style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,7 +3,7 @@ import { createStore } from 'vuex'
 export default createStore({
   state() {
     return {
-        // Array of selected images. Image objects that get selected get pushed here
+      // Array of selected images. Image objects that get selected get pushed here
       selectedImages: []
     }
   },
@@ -11,8 +11,8 @@ export default createStore({
     // This mutation changes the state of selectedImages
     // It should be dispatched when an image is selected/unselected
     toggleImageSelection(state, image) {
-        // By using the findIndex method, we check if there's an basefile_name from MockData that's the same 
-        // as the clicked image's basefilename
+      // By using the findIndex method, we check if there's an basefile_name from MockData that's the same 
+      // as the clicked image's basefilename
       const index = state.selectedImages.findIndex(img => img.basefile_name === image.basefile_name)
       // If it's in the selectedImages array, it will return a number greater than or equal to 0
       // so we splice it from the selectedImages array
@@ -22,11 +22,17 @@ export default createStore({
       } else {
         state.selectedImages.push(image)
       }
-    }
+    },
+    selectedImages(state, val) { state.selectedImages = val }
   },
   actions: {
+    // select a single image
     toggleImageSelection({ commit }, image) {
       commit('toggleImageSelection', image)
+    },
+    // pass a new array of selected images
+    setSelectedImages({ commit }, images) {
+      commit('selectedImages', images)
     }
   },
   getters: {


### PR DESCRIPTION
Implemented image list to use the vuex store so it would share a selected image array with the carousel. Now users can switch back and forth between the two different ways of viewing their images while keeping their selections. 

Future note: currently the selected images are not cleared when a project is switched. But maybe they should be kept to bring in images from multiple projects. Will need consideration. 

Changes: 
- added getters and setters to store to set entire array at once
- logic in image list to use store and load data from store on render
- linting auto changes for projectlist.js ( I'm not sure how to roll back but they follow the new rules anyways )
- removed unused-vars rule from eslint
- removed old logic that stored selectedImages as a variable in the parent of the carousel and list in favor of the store method