### PR TITLE
Feature/delete data sessions

### DIFF
--- a/src/components/DeleteSessionDialog.vue
+++ b/src/components/DeleteSessionDialog.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { fetchApiCall } from '@/utils/api';
+const props = defineProps([ 'modelValue', 'deleteId'])
+const emit = defineEmits(['update:modelValue', 'refreshDataSessions'])
+
+function closeDialog() { emit('update:modelValue', false)}
+
+async function confirmDeleteSession() {
+  if (props.deleteId != -1) {
+    console.log('deleting session with id ' + props.deleteId)
+    const url = 'http://127.0.0.1:8000/api/datasessions/'+props.deleteId+'/'
+    try {
+      await fetchApiCall(url, 'DELETE' )
+      .then(response => response.json())
+    } catch (error) {
+      console.log('error calling api: ', error)
+    }
+    emit('refreshDataSessions')
+    closeDialog()
+  }
+}
+</script>
+<template>
+  <!-- Shared dialog used to confirm deleting of sessions -->
+  <v-dialog
+    :model-value="modelValue"
+    persistent
+    width="auto"
+  >
+    <v-card>
+      <v-card-title class="text-h5" color="red-lighten-1">
+        Delete Session
+      </v-card-title>
+      <v-card-text>Are you sure you want to delete this Datalab Session? This operation is not reversible!</v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="green-darken-1"
+          variant="text"
+          @click="closeDialog()"
+        >
+          Go Back
+        </v-btn>
+        <v-btn
+          color="red-darken-1"
+          variant="text"
+          @click="confirmDeleteSession()"
+        >
+          Delete
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/src/components/DeleteSessionDialog.vue
+++ b/src/components/DeleteSessionDialog.vue
@@ -1,22 +1,17 @@
 <script setup>
 import { fetchApiCall } from '@/utils/api';
 const props = defineProps([ 'modelValue', 'deleteId'])
-const emit = defineEmits(['update:modelValue', 'refreshDataSessions'])
+const emit = defineEmits(['update:modelValue', 'reloadSession'])
 
 function closeDialog() { emit('update:modelValue', false)}
 
 async function confirmDeleteSession() {
   if (props.deleteId != -1) {
-    console.log('deleting session with id ' + props.deleteId)
-    const url = 'http://127.0.0.1:8000/api/datasessions/'+props.deleteId+'/'
-    try {
-      await fetchApiCall(url, 'DELETE' )
-      .then(response => response.json())
-    } catch (error) {
-      console.log('error calling api: ', error)
-    }
-    emit('refreshDataSessions')
-    closeDialog()
+    const url = 'http://127.0.0.1:8000/api/datasessions/' + props.deleteId
+    fetchApiCall({url:url, method:'DELETE'})
+    .then(function() {emit('reloadSession')})
+    .then(function() {closeDialog()})
+    .catch(error => console.error('Error:', error));
   }
 }
 </script>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -14,7 +14,16 @@ async function fetchApiCall({ url, method, body = null, successCallback = null, 
 
   try {
     const response = await fetch(url, config)
+
+    // Check for empty or non-JSON response
+    if (response.status === 204 || response.status === 301) {
+      // No content, handle accordingly (e.g., invoke successCallback with null)
+      if (successCallback) successCallback(null);
+      return null;
+    }
+
     const responseData = await response.json()
+
     if (!response.ok) {
       console.error('Response not OK', responseData)
       if (failCallback) {
@@ -26,7 +35,7 @@ async function fetchApiCall({ url, method, body = null, successCallback = null, 
         // invoking success callback with responsedata and returning it for further processing
         successCallback (responseData)
       }
-    } 
+    }
     return responseData
   } catch (error) {
       console.error('Error raised when sending request', error)

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -48,6 +48,6 @@ function loadAllSessions() {
         </v-window-item>
       </v-window>
     </v-card>
-    <delete-session-dialog v-model="showDeleteDialog" :deleteId="deleteSessionId" @refreshDataSessions="console.log('emitted event heard by parrent')"/>
+    <delete-session-dialog v-model="showDeleteDialog" :deleteId="deleteSessionId" @reload-session="loadAllSessions()"/>
   </v-container>
 </template>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import DataSession from '@/components/DataSession.vue';
+import DeleteSessionDialog from '@/components/DeleteSessionDialog.vue';
 
 const dataSessions = ref([]);
 const tab = ref();
 const deleteSessionId = ref(-1);
-const showDeleteSessionDialog = ref(false);
+const showDeleteDialog = ref(false);
 
 onMounted(() => {
   loadAllSessions();
@@ -13,7 +14,7 @@ onMounted(() => {
 
 function deleteSession(id) {
   deleteSessionId.value = id;
-  showDeleteSessionDialog.value = true;
+  showDeleteDialog.value = true;
 }
 
 function loadAllSessions() {
@@ -23,14 +24,6 @@ function loadAllSessions() {
   })
     .then(response => response.json())
     .then(data => dataSessions.value = data.results);
-}
-
-function confirmDeleteSession() {
-  if (deleteSessionId.value != -1) {
-    console.log('deleting session id ' + deleteSessionId.value);
-    deleteSessionId.value = -1;
-  }
-  showDeleteSessionDialog.value = false;
 }
 
 </script>
@@ -55,35 +48,6 @@ function confirmDeleteSession() {
         </v-window-item>
       </v-window>
     </v-card>
-  <!-- Shared dialog used to confirm deleting of sessions -->
-  <v-dialog
-    v-model="showDeleteSessionDialog"
-    persistent
-    width="auto"
-  >
-    <v-card>
-      <v-card-title class="text-h5" color="red-lighten-1">
-        Delete Session
-      </v-card-title>
-      <v-card-text>Are you sure you want to delete this Datalab Session? This operation is not reversible!</v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn
-          color="green-darken-1"
-          variant="text"
-          @click="showDeleteSessionDialog = false"
-        >
-          Go Back
-        </v-btn>
-        <v-btn
-          color="red-darken-1"
-          variant="text"
-          @click="confirmDeleteSession()"
-        >
-          Delete
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-dialog>
+    <delete-session-dialog v-model="showDeleteDialog" :deleteId="deleteSessionId" @refreshDataSessions="console.log('emitted event heard by parrent')"/>
   </v-container>
 </template>


### PR DESCRIPTION
New Features
- Sessions can now be deleted through the delete dialog, the page then reloads to show this change occurred
Changes
- broke off Delete Dialog into its own component for organization
- shortened name of ref for keeping track of the displayed boolean
Fixes
- added handling to the fetch api utility so that it won't cause an error when receiving empty responses
- minor spaces and lines