### PR TITLE
Feature/fetch hosted mock data

### DIFF
--- a/public/config/config.json
+++ b/public/config/config.json
@@ -1,5 +1,5 @@
 {
-  "datalabApiBaseUrl": "http://127.0.0.1:8000/api/",
+  "datalabApiBaseUrl": "https://datalab-server.photonranch.org/api/",
   "dataLabArchiveApiUrl": "https://datalab-archive.photonranch.org/",
   "observationPortalUrl": "https://observe.photonranch.org/api/"
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ onMounted(async () => {
       store.commit('setIsConfigLoaded', true)
       store.commit('setDatalabApiBaseUrl', config.datalabApiBaseUrl)
       store.commit('setObservationPortalUrl', config.observationPortalUrl)
+      store.commit('setDatalabArchiveUrl', config.dataLabArchiveApiUrl)
     }  
   } catch (error) {
     console.error('Error loading configuration:', error)

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -45,8 +45,6 @@ const getImages = async () => {
 
     const data = await response.json()
     images.value = data.input_data
-      .filter(img => !img.source.includes('archive'))
-      .map(img => img.source)
   } catch (error) {
     console.log('Error getting images: ', error)
   }
@@ -65,9 +63,10 @@ onMounted(() => {
       <v-col cols="9">
         <v-carousel v-if="images.length">
           <v-carousel-item
-            v-for="(image, index) in images"
-            :key="index"
-            :src="require('../assets/' + image)"
+            v-for="(image) in images"
+            :key="image.basename"
+            :src="image.source"
+            :alt="image.basename"
             cover
           ></v-carousel-item>
         </v-carousel>

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -8,7 +8,7 @@ const store = useStore()
 const currentSlide = ref(0)
 const props = defineProps(["data"]);
 
-let MockData = ref(props.data);
+let data = ref(props.data);
 
 // Checking if image isSelected to either add or remove yellow borderline
 const isSelected = (item) => store.getters.isSelected(item)
@@ -24,9 +24,9 @@ const handleThumbnailClick = (item, index) => {
   if (store.state.selectedImages.length > 0) {
     // If there are selected images, then we find the last selected image
     const lastSelectedImage = store.state.selectedImages[store.state.selectedImages.length - 1]
-    // Then we find the index of the last selected image in the MockData array
+    // Then we find the index of the last selected image in the data array
     // This is used to set the current slide to the last selected image
-    const lastSelectedIndex = MockData.value.findIndex(img => img.basefile_name === lastSelectedImage.basefile_name)
+    const lastSelectedIndex = data.value.findIndex(img => img.basename === lastSelectedImage.basename)
     // Set the current slide to the last selected image
     currentSlide.value = lastSelectedIndex
   } else {
@@ -39,10 +39,10 @@ const handleThumbnailClick = (item, index) => {
 
 <template>
     <!-- Main Carousel -->
-    <Carousel id="gallery" :items-to-show="1" :wrap-around="false" transition=0 v-model="currentSlide">
-      <Slide v-for="(item, index) in MockData" :key="index">
+    <Carousel id="gallery" :items-to-show="1" :wrap-around="false" :transition=0 v-model="currentSlide">
+      <Slide v-for="(item, index) in data" :key="index">
         <div class="carousel__item">
-          <img :src="require('@/assets/' + item.image)" class="div__item"/>
+          <img :src="item.url" class="div__item" :alt="item.OBJECT"/>
         </div>
       </Slide>
     </Carousel>
@@ -52,14 +52,14 @@ const handleThumbnailClick = (item, index) => {
     id="thumbnails"
     :items-to-show="5"
     :wrap-around="false"
-    transition=0
+    :transition=0
     v-model="currentSlide"
     ref="carousel"
   >
-    <Slide v-for="(item, index) in MockData" :key="index">
+    <Slide v-for="(item, index) in data" :key="index">
       <div class="thumbnail__item" @click="handleThumbnailClick(item, index)">
         <!-- Thumbnail Image -->
-        <img :src="require('@/assets/' + item.image)" :class="{'selected-thumbnail': isSelected(item)}" class="thumbnail__item"/>
+        <img :src="item.url" :class="{'selected-thumbnail': isSelected(item)}" class="thumbnail__item" :alt="item.OBJECT"/>
       </div>
     </Slide>
     <template #addons>

--- a/src/components/ProjectView/ImageList.vue
+++ b/src/components/ProjectView/ImageList.vue
@@ -7,10 +7,10 @@ const store = useStore();
 
 // v-data-table setup variables
 let headers = ref([
-  { title: "Image Name", align: "start", sortable: true, key: "basefile_name" },
-  { title: "Time", align: "start", sortable: true, key: "time" },
-  { title: "Object", align: "start", sortable: true, key: "object" },
-  { title: "Image", align: "start", sortable: false, key: "image" },
+  { title: "Image Name", align: "start", sortable: true, key: "basename" },
+  { title: "Time", align: "start", sortable: true, key: "observation_date" },
+  { title: "Object", align: "start", sortable: true, key: "OBJECT" },
+  { title: "Image", align: "start", sortable: false, key: "url" },
 ]);
 let items = ref(props.data);
 let itemsPerPage = ref(15);
@@ -31,7 +31,7 @@ onMounted ( () => {
   <v-data-table
     :headers="headers"
     :items="items"
-    item-value="basefile_name"
+    item-value="basename"
     :return-object="true"
     show-select
     v-model="selected"
@@ -40,11 +40,10 @@ onMounted ( () => {
     :hover="true"
     v-model:items-per-page="itemsPerPage"
   >
-    <!-- TODO change src to fetch image from url-->
-    <template #[`item.image`]="{ item }">
+    <template #[`item.url`]="{ item }">
       <v-img
-        :src="require('@/assets/' + item.image)"
-        :alt="item.basefile_name"
+        :src="item.url"
+        :alt="item.OBJECT"
         height="50"
         width="200"
         cover

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,7 +14,7 @@ export default createStore({
   mutations: {
     // toggle image selection
     toggleImageSelection(state, image) {
-      const index = state.selectedImages.findIndex(img => img.basefile_name === image.basefile_name)
+      const index = state.selectedImages.findIndex(img => img.basename === image.basename)
       if (index >= 0) {
         state.selectedImages.splice(index, 1)
       } else {
@@ -53,7 +53,7 @@ export default createStore({
   },
   getters: {
     isSelected: (state) => (image) => {
-      return state.selectedImages.some(selectedImage => selectedImage.basefile_name === image.basefile_name)
+      return state.selectedImages.some(selectedImage => selectedImage.basename === image.basename)
     },
     selectedImages: (state) => state.selectedImages
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,7 +6,7 @@ export default createStore({
       selectedImages: [],
       isConfigLoaded: false,
       datalabApiBaseUrl: '',
-      archiveUrl: '',
+      datalabArchiveApiUrl: '',
       observationPortalUrl: '',
       username: '',
       authToken: '',
@@ -37,8 +37,8 @@ export default createStore({
       state.datalabApiBaseUrl = url
     },
 
-    setArchiveUrl(state, url) {
-      state.archiveUrl = url
+    setDatalabArchiveUrl(state, url) {
+      state.datalabArchiveApiUrl = url
     },
     
     setObservationPortalUrl(state, url) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -35,4 +35,13 @@ async function fetchApiCall({ url, method, body = null, successCallback = null, 
   }
 }
 
-export { fetchApiCall }
+async function fetchImagesfromLinks(imageLinks){
+  // api endpoint to archive images
+  const url = ""
+  // add image link list to body in json form
+  const body = ""
+  // return the images
+  return await fetchApiCall(url, 'GET', body, console.log('success'), console.log('failure'))
+}
+
+export { fetchApiCall, fetchImagesfromLinks }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -31,14 +31,4 @@ async function fetchApiCall({ url, method, body = null, headers, successCallback
   }
 }
 
-// this util function accepts a list of s3 bitbucket image links and returns the images reflecting that list
-async function fetchImagesfromLinks(imageLinks){
-  // api endpoint to archive images
-  const url = ""
-  // add image link list to body in json form
-  const body = ""
-  // return the images
-  return await fetchApiCall(url, 'GET', body, console.log('success'), console.log('failure'))
-}
-
-export { fetchApiCall, fetchImagesfromLinks }
+export { fetchApiCall }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,10 +1,10 @@
 // handles api requests for datasessions with configurable parameters and callback functions
-async function fetchApiCall({ url, method, body = null, successCallback = null, failCallback = null }) {
+async function fetchApiCall({ url, method, body = null, successCallback = null, failCallback = null, token=null }) {
 
   const headers = {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
-    'Authorization': 'Token 123456789abcdefg',
+    'Authorization': token ? token : 'Token 123456789abcdefg',
   }
   
   const config = {
@@ -38,6 +38,7 @@ async function fetchApiCall({ url, method, body = null, successCallback = null, 
   }
 }
 
+// this util function accepts a list of s3 bitbucket image links and returns the images reflecting that list
 async function fetchImagesfromLinks(imageLinks){
   // api endpoint to archive images
   const url = ""

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -14,16 +14,18 @@ const uniqueDataSessions = ref([])
 const newSessionName = ref('')
 const errorMessage = ref('')
 const dataSessionsUrl = store.state.dataSessionsUrl
-const data = ref(null)
 let imageDisplayToggle = ref(true)
+let userFrames = ref(null)
 
-// Logic for fetching data from OCS and Archive for displaying in Projects
-const getUserImages = async () => {
-    // url and body for getting the list of the user's images
-    const url = ""
-    const body = ""
-    const imageLinks = await fetchApiCall(url, 'GET', body, console.log("success"), console.log("failure"))
-    data.value = await fetchImagesfromLinks(imageLinks)
+// Loads the user's Images from their profile into userImages
+const loadUserImages = async () => {
+    // TODO Get profile Data from store
+    // Get s3 image links for user for all proposals
+    // user links to get images from the archive
+    // cache images a ref
+    const url = 'https://datalab-archive.photonranch.org/frames/?reduction_level=95'
+    userFrames.value = await fetchApiCall({url: url, method: 'GET', token: 'Token 2da74cb5262a52bc479e5b63b548fd5910592475'})
+    console.log(userFrames.value.results)
 }
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {
@@ -127,7 +129,7 @@ const sessionNameExists = (name) => {
 }
 
 onMounted(() => {
-  getUserImages()
+  loadUserImages()
 })
 
 </script>
@@ -136,9 +138,9 @@ onMounted(() => {
     <div class="container">
         <ProjectBar class="project-bar"/>
         <div class="image-area h-screen">
-            <ImageCarousel v-if="imageDisplayToggle && data" :data="data"/>
-            <ImageList v-if="!imageDisplayToggle && data" :data="data"/>
-            <v-skeleton-loader v-else type="card"></v-skeleton-loader>
+            <ImageCarousel v-if="imageDisplayToggle && userFrames" :data="userFrames.results"/>
+            <ImageList v-if="!imageDisplayToggle && userFrames" :data="userFrames.results"/>
+            <v-skeleton-loader v-if="!userFrames" type="card"></v-skeleton-loader>
             <div class="control-buttons">
                 <v-switch class="d-flex mr-4" v-model="imageDisplayToggle" inset prepend-icon="mdi-view-list" append-icon="mdi-image"/>
                 <v-btn :disabled="noSelectedImages" @click="getDataSessions">Add to a Session</v-btn>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -27,8 +27,8 @@ let imageDisplayToggle = ref(true)
 let userFrames = ref(null)
 
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
-const loadUserImages = async () => {
-    const url = archiveUrl + 'frames/?reduction_level=95'
+const loadUserImages = async (option) => {
+    const url = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
     userFrames.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders})
 }
 // boolean computed property used to disable the add to session button
@@ -132,7 +132,7 @@ const sessionNameExists = (name) => {
 }
 
 onMounted(() => {
-  loadUserImages()
+  loadUserImages('reduction_level=95')
 })
 
 </script>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -29,7 +29,7 @@ let userFrames = ref(null)
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async () => {
     const url = archiveUrl + 'frames/?reduction_level=95'
-    userFrames.value = await fetchApiCall({url: url, method: 'GET', token: 'Token 2da74cb5262a52bc479e5b63b548fd5910592475'})
+    userFrames.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders})
 }
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -25,7 +25,6 @@ const loadUserImages = async () => {
     // cache images a ref
     const url = 'https://datalab-archive.photonranch.org/frames/?reduction_level=95'
     userFrames.value = await fetchApiCall({url: url, method: 'GET', token: 'Token 2da74cb5262a52bc479e5b63b548fd5910592475'})
-    console.log(userFrames.value.results)
 }
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {
@@ -58,7 +57,6 @@ const getDataSessions = async () => {
 // updates an existing session with selected images
 const addImagesToExistingSession = async (session) => {
     const sessionIdUrl = dataSessionsUrl + session.id + '/'
-    console.log('sessionidurl', sessionIdUrl)
     try {
         // fetches existing session data
         const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
@@ -102,8 +100,8 @@ const createNewDataSession = async () => {
     }
     const selectedImages = store.state.selectedImages
     const inputData = selectedImages.map(image => ({
-        'source': image.image,
-        'basename': image.basefile_name
+        'source': image.url,
+        'basename': image.basename
     }))
     const requestBody = { 
         'name': newSessionName.value,

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -1,15 +1,11 @@
 <script setup>
-// libraries
-import { ref, computed } from 'vue'
-// components
+import { ref, computed, onMounted } from 'vue'
 import ProjectBar from '@/components/ProjectView/ProjectBar.vue';
 import ImageCarousel from '@/components/ProjectView/ImageCarousel.vue';
 import ImageList from '@/components/ProjectView/ImageList.vue';
-// data
-import MockData from '../assets/MockData.JSON'
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
-import { fetchApiCall } from '../utils/api'
+import { fetchApiCall, fetchImagesfromLinks } from '../utils/api'
 
 const router = useRouter()
 const store = useStore()
@@ -18,10 +14,17 @@ const uniqueDataSessions = ref([])
 const newSessionName = ref('')
 const errorMessage = ref('')
 const dataSessionsUrl = store.state.dataSessionsUrl
-
-// toggle for optional data viewing, controlled by a v-switch
+const data = ref(null)
 let imageDisplayToggle = ref(true)
 
+// Logic for fetching data from OCS and Archive for displaying in Projects
+const getUserImages = async () => {
+    // url and body for getting the list of the user's images
+    const url = ""
+    const body = ""
+    const imageLinks = await fetchApiCall(url, 'GET', body, console.log("success"), console.log("failure"))
+    data.value = await fetchImagesfromLinks(imageLinks)
+}
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {
   return store.getters.selectedImages.length === 0
@@ -123,14 +126,19 @@ const sessionNameExists = (name) => {
     return uniqueDataSessions.value.some(session => session.name === name)
 }
 
+onMounted(() => {
+  getUserImages()
+})
+
 </script>
 <template>
     <!-- only load if config is loaded -->
     <div class="container">
         <ProjectBar class="project-bar"/>
-        <div class="image-area">
-            <ImageCarousel v-if="imageDisplayToggle" :data="MockData"/>
-            <ImageList v-if="!imageDisplayToggle" :data="MockData"/>
+        <div class="image-area h-screen">
+            <ImageCarousel v-if="imageDisplayToggle && data" :data="data"/>
+            <ImageList v-if="!imageDisplayToggle && data" :data="data"/>
+            <v-skeleton-loader v-else type="card"></v-skeleton-loader>
             <div class="control-buttons">
                 <v-switch class="d-flex mr-4" v-model="imageDisplayToggle" inset prepend-icon="mdi-view-list" append-icon="mdi-image"/>
                 <v-btn :disabled="noSelectedImages" @click="getDataSessions">Add to a Session</v-btn>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -5,7 +5,7 @@ import ImageCarousel from '@/components/ProjectView/ImageCarousel.vue';
 import ImageList from '@/components/ProjectView/ImageList.vue';
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
-import { fetchApiCall, fetchImagesfromLinks } from '../utils/api'
+import { fetchApiCall } from '../utils/api'
 
 const router = useRouter()
 const store = useStore()
@@ -14,6 +14,7 @@ const uniqueDataSessions = ref([])
 const newSessionName = ref('')
 const errorMessage = ref('')
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
+const archiveUrl = store.state.datalabArchiveApiUrl
 
 const authHeaders = {
     'Content-Type': 'application/json',
@@ -25,13 +26,9 @@ const authHeaders = {
 let imageDisplayToggle = ref(true)
 let userFrames = ref(null)
 
-// Loads the user's Images from their profile into userImages
+// Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async () => {
-    // TODO Get profile Data from store
-    // Get s3 image links for user for all proposals
-    // user links to get images from the archive
-    // cache images a ref
-    const url = 'https://datalab-archive.photonranch.org/frames/?reduction_level=95'
+    const url = archiveUrl + 'frames/?reduction_level=95'
     userFrames.value = await fetchApiCall({url: url, method: 'GET', token: 'Token 2da74cb5262a52bc479e5b63b548fd5910592475'})
 }
 // boolean computed property used to disable the add to session button


### PR DESCRIPTION
New
- Function loadUserImages that fetches all frames with an authtoken from the archive, called on component mount and stores frames in a ref named UserFrames
- ref userFrames that holds the user's images from the archive
- A skeleton loader that is displayed when we don't have the image data on hand yet

Changed
- updating property names so that images will be working from the new format instead of the mock data format
- pointing the datalab api url to the server link instead of a locally running instance
- removed the filter and map step when displaying data session images so that the key and alt text can be the file name instead of an index for future image operation selection.

Fixes
- missing image alt text
- binding of transition to a number with v-bind instead of treating the 0 as a string which caused warnings

Side note: we have updated the datalab url to point to the server api instead of a local one. However the original implementation didn't use the fetchApi util and so Data Session View is non functional. A fix updating all of those api requests to use the store url and api util function will fix this.

![Screenshot 2024-01-29 at 2 15 43 PM](https://github.com/LCOGT/datalab-ui/assets/54085254/3ac18ac8-dbcf-4e49-8dcb-fe5891a4e0d3)
