### PR TITLE
Fix/update datasession api fetches

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, defineEmits, defineProps } from 'vue'
 import OperationPipeline from './OperationPipeline.vue'
 import { fetchApiCall, handleError } from '../utils/api'
 import { useStore } from 'vuex'

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -29,7 +29,7 @@ async function addOperation(operationDefinition) {
 
 const getImages = async () => {
 	const url = dataSessionsUrl + props.data.id
-	const data = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, successCallback: emit('reloadSession'), failCallback: handleError})
+	const data = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, failCallback: handleError})
 	images.value = data.input_data
 }
 

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -29,8 +29,7 @@ async function addOperation(operationDefinition) {
 
 const getImages = async () => {
 	const url = dataSessionsUrl + props.data.id
-	const data = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, failCallback: handleError})
-	images.value = data.input_data
+	await fetchApiCall({url: url, method: 'GET', headers: authHeaders, successCallback: (data) => {images.value = data.input_data}, failCallback: handleError})
 }
 
 onMounted(() => {

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -1,9 +1,19 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import OperationPipeline from './OperationPipeline.vue'
+import { fetchApiCall, handleError } from '../utils/api'
+import { useStore } from 'vuex'
 
+const store = useStore()
 const emit = defineEmits(['reloadSession'])
 let images = ref([])
+const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
+
+const authHeaders = {
+	'Content-Type': 'application/json',
+	'Accept': 'application/json',
+	'Authorization': `Token ${store.state.authToken}`,
+}
 
 const props = defineProps({
 	data: {
@@ -12,43 +22,15 @@ const props = defineProps({
 	}
 })
 
-function addOperation(operationDefinition) {
-	// Create data operation in this session with input parameters specified from wizard
-	fetch('http://127.0.0.1:8000/api/datasessions/' + props.data.id + '/operations/', {
-		'method': 'POST',
-		'body': JSON.stringify(operationDefinition),
-		'headers': {
-			'Authorization': 'Token 123456789abcdefg',
-			'Content-type': 'application/json; charset=UTF-8'
-		}
-	})
-		.then(response => response.json())
-		.then(function() {emit('reloadSession')})
-		.catch(error => console.error('Error:', error))
+async function addOperation(operationDefinition) {
+	const url = dataSessionsUrl + props.data.id + '/operations/'
+	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, headers: authHeaders, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
 const getImages = async () => {
-	try {
-		const response = await fetch ('http://127.0.0.1:8000/api/datasessions/' + props.data.id, {
-			method: 'GET',
-			headers: {
-				'Authorization': 'Token 123456789abcdefg',
-				'Content-Type': 'application/json; charset=UTF-8'
-			}
-		})
-
-		if (!response.ok) {
-			const errorData = await response.json()
-			console.error('Error Response Data:', errorData)
-			throw new Error('Bad request')
-		}
-
-		const data = await response.json()
-		images.value = data.input_data
-	} catch (error) {
-		console.log('Error getting images: ', error)
-	}
-
+	const url = dataSessionsUrl + props.data.id
+	const data = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, successCallback: emit('reloadSession'), failCallback: handleError})
+	images.value = data.input_data
 }
 
 onMounted(() => {

--- a/src/components/DeleteSessionDialog.vue
+++ b/src/components/DeleteSessionDialog.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/require-prop-types -->
 <script setup>
-import { ref } from 'vue'
+import { ref, defineProps, defineEmits } from 'vue'
 import { fetchApiCall } from '@/utils/api'
 import { useStore } from 'vuex'
 

--- a/src/components/OperationPipeline.vue
+++ b/src/components/OperationPipeline.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, defineEmits, defineProps} from 'vue'
 import OperationWizard from './OperationWizard.vue'
 
 const emit = defineEmits(['addOperation'])

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -19,7 +19,7 @@ const selectedOperationInput = ref({})
 
 onMounted(async () => {
 	const url = dataSessionsUrl + 'available_operations/'
-	availableOperations.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, failCallback: handleError})
+	await fetchApiCall({url: url, method: 'GET', headers: authHeaders, successCallback: (data) => {availableOperations.value = data}, failCallback: handleError})
 	if (Object.keys(availableOperations.value).length > 0){
 		selectedOperation.value = Object.keys(availableOperations.value)[0]
 	}

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -1,25 +1,28 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue'
+import { fetchApiCall, handleError } from '../utils/api'
+import { useStore } from 'vuex'
 
+const store = useStore()
 const emit = defineEmits(['closeWizard', 'addOperation'])
+const dataSessionsUrl = store.state.datalabApiBaseUrl
+
+const authHeaders = {
+	'Content-Type': 'application/json',
+	'Accept': 'application/json',
+	'Authorization': `Token ${store.state.authToken}`,
+}
 
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 
-onMounted(() => {
-	// Load in the session details from the API
-	// Long term, the available operations should be loaded into the store once on page load and retrieved from there
-	fetch('http://127.0.0.1:8000/api/available_operations/', {
-		'headers': {'Authorization': 'Token 123456789abcdefg'}
-	})
-		.then(response => response.json())
-		.then(data => {
-			availableOperations.value = data
-			if (Object.keys(availableOperations.value).length > 0){
-				selectedOperation.value = Object.keys(availableOperations.value)[0]
-			}
-		})
+onMounted(async () => {
+  const url = dataSessionsUrl + 'available_operations/'
+  availableOperations.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, failCallback: handleError})
+  if (Object.keys(availableOperations.value).length > 0){
+    selectedOperation.value = Object.keys(availableOperations.value)[0]
+  }
 })
 
 const page = ref('select')

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted, computed, defineEmits } from 'vue'
 import { fetchApiCall, handleError } from '../utils/api'
 import { useStore } from 'vuex'
 
@@ -18,11 +18,11 @@ const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 
 onMounted(async () => {
-  const url = dataSessionsUrl + 'available_operations/'
-  availableOperations.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, failCallback: handleError})
-  if (Object.keys(availableOperations.value).length > 0){
-    selectedOperation.value = Object.keys(availableOperations.value)[0]
-  }
+	const url = dataSessionsUrl + 'available_operations/'
+	availableOperations.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders, failCallback: handleError})
+	if (Object.keys(availableOperations.value).length > 0){
+		selectedOperation.value = Object.keys(availableOperations.value)[0]
+	}
 })
 
 const page = ref('select')

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/require-prop-types -->
 <script setup>
-import { ref } from 'vue'
+import { ref, defineProps } from 'vue'
 import { useStore } from 'vuex'
 import { Carousel, Slide, Navigation } from 'vue3-carousel'
 import 'vue3-carousel/dist/carousel.css'

--- a/src/components/ProjectView/ImageList.vue
+++ b/src/components/ProjectView/ImageList.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/require-prop-types -->
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, defineProps } from 'vue'
 import { useStore } from 'vuex'
 
 const props = defineProps(['data'])

--- a/src/components/ProjectView/ProjectSelector.vue
+++ b/src/components/ProjectView/ProjectSelector.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/require-prop-types -->
 <script setup>
+import { defineProps } from 'vue'
 defineProps(['project'])
 
 </script>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -31,4 +31,9 @@ async function fetchApiCall({ url, method, body = null, headers, successCallback
 	}
 }
 
-export { fetchApiCall }
+// manages api call failures by logging errors
+const handleError = (error) => {
+	console.error('API call failed with error:', error)
+}
+
+export { fetchApiCall, handleError }

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -1,12 +1,22 @@
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useStore } from 'vuex'
+import { fetchApiCall, handleError } from '../utils/api'
 import DataSession from '@/components/DataSession.vue'
 import DeleteSessionDialog from '@/components/DeleteSessionDialog.vue'
 
+const store = useStore()
 const dataSessions = ref([])
 const tab = ref()
 const deleteSessionId = ref(-1)
 const showDeleteDialog = ref(false)
+const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
+
+const authHeaders = {
+	'Content-Type': 'application/json',
+	'Accept': 'application/json',
+	'Authorization': `Token ${store.state.authToken}`,
+}
 
 onMounted(() => {
 	loadAllSessions()
@@ -17,13 +27,9 @@ function deleteSession(id) {
 	showDeleteDialog.value = true
 }
 
-function loadAllSessions() {
-	// Load in the session details from the API
-	fetch('http://127.0.0.1:8000/api/datasessions/', {
-		'headers': {'Authorization': 'Token 123456789abcdefg'}
-	})
-		.then(response => response.json())
-		.then(data => dataSessions.value = data.results)
+async function loadAllSessions() {
+  const data = await fetchApiCall({url: dataSessionsUrl, method: 'GET', headers: authHeaders, failCallback: handleError})
+	dataSessions.value = data.results
 }
 
 </script>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -28,7 +28,7 @@ function deleteSession(id) {
 }
 
 async function loadAllSessions() {
-  const data = await fetchApiCall({url: dataSessionsUrl, method: 'GET', headers: authHeaders, failCallback: handleError})
+	const data = await fetchApiCall({url: dataSessionsUrl, method: 'GET', headers: authHeaders, failCallback: handleError})
 	dataSessions.value = data.results
 }
 

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -28,8 +28,7 @@ function deleteSession(id) {
 }
 
 async function loadAllSessions() {
-	const data = await fetchApiCall({url: dataSessionsUrl, method: 'GET', headers: authHeaders, failCallback: handleError})
-	dataSessions.value = data.results
+	await fetchApiCall({url: dataSessionsUrl, method: 'GET', headers: authHeaders, successCallback: (data) => {dataSessions.value = data.results}, failCallback: handleError})
 }
 
 </script>


### PR DESCRIPTION
Putting up a working PR but could use some improvements, since this fixes the site temporarily however I think it should be added and the improvements added on another PR. Open to changing them in this one, but won't be ready for the demo.

When the url for the datalab api was changed in the config one PR ago we didn't change the old fetch requests that were still pointing towards the locally hosted api. Updated plain fetch requests with the util function and pointed them to the server api.

Improvements/Tech Debt for a follow up story:

- initially followed the way it was done and copied auth headers for every file that needs a token request. Should be moved to a shared file or handled in the api util. This way the headers parameter can be eliminated from most calls, but still have the option to have a custom header if needed
 - n̶o̶t̶ ̶u̶s̶i̶n̶g̶ ̶t̶h̶e̶ ̶s̶u̶c̶c̶e̶s̶s̶ ̶c̶a̶l̶l̶b̶a̶c̶k̶s̶,̶ ̶w̶a̶n̶t̶e̶d̶ ̶t̶o̶ ̶t̶h̶i̶n̶k̶ ̶m̶o̶r̶e̶ ̶o̶n̶ ̶a̶ ̶c̶l̶e̶a̶n̶ ̶w̶a̶y̶ ̶t̶o̶ ̶i̶m̶p̶l̶e̶m̶e̶n̶t̶ ̶c̶a̶l̶l̶b̶a̶c̶k̶ ̶f̶u̶n̶c̶t̶i̶o̶n̶s̶ ̶t̶o̶ ̶d̶o̶ ̶t̶h̶e̶ ̶s̶m̶a̶l̶l̶ ̶t̶a̶s̶k̶s̶ ̶r̶e̶q̶u̶i̶r̶e̶d̶ ̶b̶y̶ ̶m̶o̶s̶t̶ ̶c̶a̶l̶l̶s̶ ̶
- added the handle error to the api util function that just prints out the error to console, but errors should be handled on a case by case basis to allow elegant failure