### PR TITLE
Feature/display large images

### DIFF
--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -16,16 +16,20 @@ let data = ref(props.data)
 // Checking if image isSelected to either add or remove yellow borderline
 const isSelected = (item) => store.getters.isSelected(item)
 
-const getLargeImageBasename = () => {
-	const largeImages = store.state.largeImages
-	// loading first large image for user to see when they first navigate the page
-	if (!smallImageBasename.value) {
-		largeImageSrc.value = largeImages[0].url
-	} else {
-		let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
-		largeImageSrc.value = selectedLargeImage.url
+const getLargeImageSource = () => {
+	if (store.state.largeImages) {
+		const largeImages = store.state.largeImages
+		console.log('largeimages:', largeImages[0].url)
+		// loading first large image for user to see when they first navigate the page
+		if (!smallImageBasename.value) {
+			console.log('we are here')
+			largeImageSrc.value = largeImages[0].url
+		} else {
+			let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
+			largeImageSrc.value = selectedLargeImage.url
+		}	
 	}
-	
+
 }
 // Invoked any time an image is clicked
 const handleThumbnailClick = (item, index) => {
@@ -39,11 +43,11 @@ const handleThumbnailClick = (item, index) => {
 	} else {
 		currentSlide.value = index
 	}
-	getLargeImageBasename()
+	getLargeImageSource()
 }
 
 onMounted(() => {
-	handleThumbnailClick()
+	getLargeImageSource()
 })
 
 </script>

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -108,6 +108,10 @@ const getImageSrc = (src) => {
 </template>
 
 <style scoped>
+
+.carousel__item {
+  padding-bottom: 2em;
+}
 .thumbnail__item {
   max-width: 200px;
   max-height: 160px;

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -18,7 +18,7 @@ const isSelected = (item) => store.getters.isSelected(item)
 
 // Getting large images by using the thumbnail's basename and finding the large image that matches it
 const getLargeImageSource = () => {
-	const largeImages = store.state.imageCache
+	const largeImages = store.state.largeImageCache
 	let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
 	largeImageSrc.value = selectedLargeImage ? selectedLargeImage.url : ''
 }

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/require-prop-types -->
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { Carousel, Slide, Navigation } from 'vue3-carousel'
 import 'vue3-carousel/dist/carousel.css'
@@ -8,25 +8,44 @@ import 'vue3-carousel/dist/carousel.css'
 const store = useStore()
 const currentSlide = ref(0)
 const props = defineProps(['data'])
+let smallImageBasename = ref('')
+let largeImageSrc = ref('')
 
 let data = ref(props.data)
 
 // Checking if image isSelected to either add or remove yellow borderline
 const isSelected = (item) => store.getters.isSelected(item)
 
+const getLargeImageBasename = () => {
+	const largeImages = store.state.largeImages
+	// loading first large image for user to see when they first navigate the page
+	if (!smallImageBasename.value) {
+		largeImageSrc.value = largeImages[0].url
+	} else {
+		let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
+		largeImageSrc.value = selectedLargeImage.url
+	}
+	
+}
 // Invoked any time an image is clicked
 const handleThumbnailClick = (item, index) => {
 	store.dispatch('toggleImageSelection', item)
-
 	// Checking if there are any selected images after the toggle action
 	if (store.state.selectedImages.length > 0) {
 		const lastSelectedImage = store.state.selectedImages[store.state.selectedImages.length - 1]
 		const lastSelectedIndex = data.value.findIndex(img => img.basename === lastSelectedImage.basename)
 		currentSlide.value = lastSelectedIndex
+		smallImageBasename.value = lastSelectedImage.basename.replace('-small', '')
 	} else {
 		currentSlide.value = index
 	}
+	getLargeImageBasename()
 }
+
+onMounted(() => {
+	handleThumbnailClick()
+})
+
 </script>
 
 <template>
@@ -44,7 +63,7 @@ const handleThumbnailClick = (item, index) => {
     >
       <div class="carousel__item">
         <img
-          :src="item.url"
+          :src="largeImageSrc"
           class="div__item"
           :alt="item.OBJECT"
         >

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -18,9 +18,9 @@ const isSelected = (item) => store.getters.isSelected(item)
 
 // Getting large images by using the thumbnail's basename and finding the large image that matches it
 const getLargeImageSource = () => {
-	const largeImages = store.state.largeImages
+	const largeImages = store.state.imageCache
 	let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
-	largeImageSrc.value = selectedLargeImage.url
+	largeImageSrc.value = selectedLargeImage ? selectedLargeImage.url : ''
 }
 
 // Invoked any time an image is clicked

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -22,6 +22,7 @@ const getLargeImageSource = () => {
 	let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
 	largeImageSrc.value = selectedLargeImage.url
 }
+
 // Invoked any time an image is clicked
 const handleThumbnailClick = (item, index) => {
 	store.dispatch('toggleImageSelection', item)

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -39,6 +39,9 @@ const handleThumbnailClick = (item, index) => {
 	getLargeImageSource()
 }
 
+const getImageSrc = (src) => {
+	return src || store.getters.firstLargeImage || ''
+}
 
 </script>
 
@@ -57,10 +60,17 @@ const handleThumbnailClick = (item, index) => {
     >
       <div class="carousel__item">
         <img
-          :src="largeImageSrc ? largeImageSrc : store.state.firstLargeImage"
+          v-if="getImageSrc(largeImageSrc)"
+          :src="getImageSrc(largeImageSrc)"
           class="div__item"
           :alt="item.OBJECT"
         >
+        <v-progress-circular
+          v-else
+          indeterminate
+          :size="51"
+          :width="10"
+        />
       </div>
     </Slide>
   </Carousel>

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -16,23 +16,14 @@ const isSelected = (item) => store.getters.isSelected(item)
 
 // Invoked any time an image is clicked
 const handleThumbnailClick = (item, index) => {
-	// Dispatch an action to toggle the selection status of the clicked image
-	// This will add the image to the selectedImages array in the store if it's not there
-	// or remove it if it is already in the array
 	store.dispatch('toggleImageSelection', item)
 
 	// Checking if there are any selected images after the toggle action
 	if (store.state.selectedImages.length > 0) {
-		// If there are selected images, then we find the last selected image
 		const lastSelectedImage = store.state.selectedImages[store.state.selectedImages.length - 1]
-		// Then we find the index of the last selected image in the data array
-		// This is used to set the current slide to the last selected image
 		const lastSelectedIndex = data.value.findIndex(img => img.basename === lastSelectedImage.basename)
-		// Set the current slide to the last selected image
 		currentSlide.value = lastSelectedIndex
 	} else {
-		// If no images are selected, set the current slide to the index of the clicked image
-		// This ensures that the carousel shows the clicked image
 		currentSlide.value = index
 	}
 }

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -16,8 +16,8 @@ let data = ref(props.data)
 // Checking if image isSelected to either add or remove yellow borderline
 const isSelected = (item) => store.getters.isSelected(item)
 
+// Getting large images by using the thumbnail's basename and finding the large image that matches it
 const getLargeImageSource = () => {
-	// loading first large image for user to see when they first navigate the page
 	const largeImages = store.state.largeImages
 	let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
 	largeImageSrc.value = selectedLargeImage.url
@@ -31,6 +31,7 @@ const handleThumbnailClick = (item, index) => {
 		const lastSelectedImage = store.state.selectedImages[store.state.selectedImages.length - 1]
 		const lastSelectedIndex = data.value.findIndex(img => img.basename === lastSelectedImage.basename)
 		currentSlide.value = lastSelectedIndex
+		// Used to get large images
 		smallImageBasename.value = lastSelectedImage.basename.replace('-small', '')
 	} else {
 		currentSlide.value = index

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -60,17 +60,10 @@ const getImageSrc = (src) => {
     >
       <div class="carousel__item">
         <img
-          v-if="getImageSrc(largeImageSrc)"
           :src="getImageSrc(largeImageSrc)"
           class="div__item"
           :alt="item.OBJECT"
         >
-        <v-progress-circular
-          v-else
-          indeterminate
-          :size="51"
-          :width="10"
-        />
       </div>
     </Slide>
   </Carousel>

--- a/src/components/ProjectView/ImageCarousel.vue
+++ b/src/components/ProjectView/ImageCarousel.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/require-prop-types -->
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref } from 'vue'
 import { useStore } from 'vuex'
 import { Carousel, Slide, Navigation } from 'vue3-carousel'
 import 'vue3-carousel/dist/carousel.css'
@@ -17,19 +17,10 @@ let data = ref(props.data)
 const isSelected = (item) => store.getters.isSelected(item)
 
 const getLargeImageSource = () => {
-	if (store.state.largeImages) {
-		const largeImages = store.state.largeImages
-		console.log('largeimages:', largeImages[0].url)
-		// loading first large image for user to see when they first navigate the page
-		if (!smallImageBasename.value) {
-			console.log('we are here')
-			largeImageSrc.value = largeImages[0].url
-		} else {
-			let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
-			largeImageSrc.value = selectedLargeImage.url
-		}	
-	}
-
+	// loading first large image for user to see when they first navigate the page
+	const largeImages = store.state.largeImages
+	let selectedLargeImage = largeImages.find(obj => obj.basename.replace('-large', '') === smallImageBasename.value)
+	largeImageSrc.value = selectedLargeImage.url
 }
 // Invoked any time an image is clicked
 const handleThumbnailClick = (item, index) => {
@@ -46,9 +37,6 @@ const handleThumbnailClick = (item, index) => {
 	getLargeImageSource()
 }
 
-onMounted(() => {
-	getLargeImageSource()
-})
 
 </script>
 
@@ -67,7 +55,7 @@ onMounted(() => {
     >
       <div class="carousel__item">
         <img
-          :src="largeImageSrc"
+          :src="largeImageSrc ? largeImageSrc : store.state.firstLargeImage"
           class="div__item"
           :alt="item.OBJECT"
         >

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,7 +12,8 @@ export default createStore({
 			authToken: '',
 			profile: [],
 			projects: [],
-			largeImages: []
+			largeImages: [],
+			firstLargeImage: ''
 		}
 	},
 
@@ -68,6 +69,10 @@ export default createStore({
 			for (const image of images) {
 				state.largeImages.push(image)
 			}
+		},
+
+		setFirstLargeImage(state, image) {
+			state.firstLargeImage = image
 		}
 	},
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -18,7 +18,8 @@ export default createStore({
 			datalabArchiveApiUrl: '',
 			observationPortalUrl: '',
 			projects: [],
-			imageCache: []
+			largeImageCache: [],
+			smallImageCache: []
 		}
 	},
 
@@ -58,13 +59,19 @@ export default createStore({
 			}
 		},
 
-		cacheImages(state, imageData) {
+		setImageCache(state, imageData) {
 			imageData.forEach(image => {
-				const existingImageIndex = state.imageCache.findIndex(img => img.basename === image.basename)
-				if (existingImageIndex === -1) {
-					state.imageCache.push(image)
+				let imageArray
+				if (image.RLEVEL === 95) {
+					imageArray = state.smallImageCache
 				} else {
-					state.imageCache[existingImageIndex] = image
+					imageArray = state.largeImageCache
+				}
+				const existingImageIndex = imageArray.findIndex(img => img.basename === image.basename)
+				if (existingImageIndex === -1) {
+					imageArray.push(image)
+				} else {
+					imageArray[existingImageIndex] = image
 				}
 			})
 		},
@@ -91,7 +98,7 @@ export default createStore({
 	
 			const responseData = await fetchApiCall({ url: imageUrl, method: 'GET', headers: authHeaders })
 			if (responseData && responseData.results) {
-				commit('cacheImages', responseData.results)
+				commit('setImageCache', responseData.results)
 			}
 		}
 	},
@@ -103,8 +110,8 @@ export default createStore({
 		selectedImages: (state) => state.selectedImages,
 
 		firstLargeImage: (state) => {
-			if (state.imageCache.length) {
-				return state.imageCache[0].url
+			if (state.largeImageCache.length) {
+				return state.largeImageCache[0].url
 			}
 		}
 	}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,9 +17,6 @@ export default createStore({
 			datalabApiBaseUrl: '',
 			datalabArchiveApiUrl: '',
 			observationPortalUrl: '',
-			username: '',
-			authToken: '',
-			profile: [],
 			projects: [],
 			imageCache: []
 		}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -65,9 +65,7 @@ export default createStore({
 		},
 
 		setLargeImages(state, images) {
-			for (const image of images) {
-				state.largeImages.push(image)
-			}
+			state.largeImages = images
 		}
 	},
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,8 +12,7 @@ export default createStore({
 			authToken: '',
 			profile: [],
 			projects: [],
-			largeImages: [],
-			firstLargeImage: ''
+			largeImages: []
 		}
 	},
 
@@ -69,10 +68,6 @@ export default createStore({
 			for (const image of images) {
 				state.largeImages.push(image)
 			}
-		},
-
-		setFirstLargeImage(state, image) {
-			state.firstLargeImage =image
 		}
 	},
 
@@ -80,6 +75,7 @@ export default createStore({
 		toggleImageSelection({ commit }, image) {
 			commit('toggleImageSelection', image)
 		},
+
 		// pass a new array of selected images
 		setSelectedImages({ commit }, images) {
 			commit('selectedImages', images)
@@ -89,6 +85,13 @@ export default createStore({
 		isSelected: (state) => (image) => {
 			return state.selectedImages.some(selectedImage => selectedImage.basename === image.basename)
 		},
-		selectedImages: (state) => state.selectedImages
+
+		selectedImages: (state) => state.selectedImages,
+
+		firstLargeImage: (state) => {
+			if (state.largeImages.length) {
+				return state.largeImages[0].url
+			}
+		}
 	}
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,7 +11,8 @@ export default createStore({
 			username: '',
 			authToken: '',
 			profile: [],
-			projects: []
+			projects: [],
+			largeImages: []
 		}
 	},
 
@@ -60,6 +61,12 @@ export default createStore({
 		setProjects(state, projects) {
 			for (const project of projects) {
 				state.projects.push(project)
+			}
+		},
+
+		setLargeImages(state, images) {
+			for (const image of images) {
+				state.largeImages.push(image)
 			}
 		}
 	},

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -72,7 +72,7 @@ export default createStore({
 		},
 
 		setFirstLargeImage(state, image) {
-			state.firstLargeImage = image
+			state.firstLargeImage =image
 		}
 	},
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -62,11 +62,7 @@ export default createStore({
 		setImageCache(state, imageData) {
 			imageData.forEach(image => {
 				let imageArray
-				if (image.RLEVEL === 95) {
-					imageArray = state.smallImageCache
-				} else {
-					imageArray = state.largeImageCache
-				}
+				image.RLEVEL === 95 ? imageArray = state.smallImageCache : imageArray = state.largeImageCache
 				const existingImageIndex = imageArray.findIndex(img => img.basename === image.basename)
 				if (existingImageIndex === -1) {
 					imageArray.push(image)
@@ -87,16 +83,11 @@ export default createStore({
 			commit('selectedImages', images)
 		},
 
-		async loadAndCacheImages({ state, commit }, { option }) {
+		async loadAndCacheImages({ commit }, { option }) {
 			const baseUrl = this.state.datalabArchiveApiUrl + 'frames/'
 			const imageUrl = option ? `${baseUrl}?${option}` : baseUrl
-			const authHeaders = {
-				'Content-Type': 'application/json',
-				'Accept': 'application/json',
-				'Authorization': `Token ${state.authToken}`,
-			}
 	
-			const responseData = await fetchApiCall({ url: imageUrl, method: 'GET', headers: authHeaders })
+			const responseData = await fetchApiCall({ url: imageUrl, method: 'GET' })
 			if (responseData && responseData.results) {
 				commit('setImageCache', responseData.results)
 			}

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -133,7 +133,6 @@ const sessionNameExists = (name) => {
 
 const saveLargeImages = async (data) => {
 	const largeImages = await data.results
-	console.log('largeimages:', largeImages[0].url)
 	store.commit('setLargeImages', largeImages)
 	store.commit('setFirstLargeImage', largeImages[0].url)
 }

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -133,7 +133,9 @@ const sessionNameExists = (name) => {
 
 const saveLargeImages = async (data) => {
 	const largeImages = await data.results
+	console.log('largeimages:', largeImages[0].url)
 	store.commit('setLargeImages', largeImages)
+	store.commit('setFirstLargeImage', largeImages[0].url)
 }
 
 const loadLargeImages = async (option) => {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -131,11 +131,14 @@ const sessionNameExists = (name) => {
 	return uniqueDataSessions.value.some(session => session.name === name)
 }
 
+const saveLargeImages = async (data) => {
+	const largeImages = await data.results
+	store.commit('setLargeImages', largeImages)
+}
+
 const loadLargeImages = async (option) => {
 	const loadLargeImageUrl = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
-	const response = await fetchApiCall({url: loadLargeImageUrl, method: 'GET', headers: authHeaders})
-	const largeImages = response.results
-	store.commit('setLargeImages', largeImages)
+	await fetchApiCall({url: loadLargeImageUrl, method: 'GET', headers: authHeaders, successCallback: saveLargeImages})
 }
 
 onMounted(() => {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -31,6 +31,7 @@ const loadUserImages = async (option) => {
 	const url = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
 	userFrames.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders})
 }
+
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {
 	return store.getters.selectedImages.length === 0
@@ -89,7 +90,6 @@ const addImagesToExistingSession = async (session) => {
 	}
 }
 
-
 // closes popup, invokes addImagesToExistingSession, and reroutes user to DataSessions view
 const selectDataSession = (session) => {
 	isPopupVisible.value = false
@@ -131,8 +131,16 @@ const sessionNameExists = (name) => {
 	return uniqueDataSessions.value.some(session => session.name === name)
 }
 
+const loadLargeImages = async (option) => {
+	const loadLargeImageUrl = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
+	const response = await fetchApiCall({url: loadLargeImageUrl, method: 'GET', headers: authHeaders})
+	const largeImages = response.results
+	store.commit('setLargeImages', largeImages)
+}
+
 onMounted(() => {
 	loadUserImages('reduction_level=95')
+	loadLargeImages('reduction_level=96')
 })
 
 </script>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -15,18 +15,16 @@ const newSessionName = ref('')
 const errorMessage = ref('')
 const isLoading = ref(true)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
-const archiveUrl = store.state.datalabArchiveApiUrl
 
 // toggle for optional data viewing, controlled by a v-switch
 let imageDisplayToggle = ref(true)
-let userFrames = ref(null)
 
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async (option) => {
 	isLoading.value = true
-	const url = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
-	userFrames.value = await fetchApiCall({url: url, method: 'GET'})
+	await store.dispatch('loadAndCacheImages', { option })
 	isLoading.value = false
+  
 }
 
 // boolean computed property used to disable the add to session button
@@ -128,15 +126,9 @@ const sessionNameExists = (name) => {
 	return uniqueDataSessions.value.some(session => session.name === name)
 }
 
-const loadLargeImages = async (option) => {
-	isLoading.value = true
-	await store.dispatch('loadAndCacheImages', { option })
-	isLoading.value = false
-}
-
 onMounted(() => {
 	loadUserImages('reduction_level=95')
-	loadLargeImages('reduction_level=96')
+	loadUserImages('reduction_level=96')
 })
 
 </script>
@@ -159,16 +151,16 @@ onMounted(() => {
 
       <div v-else>
         <ImageCarousel
-          v-if="imageDisplayToggle && userFrames"
-          :data="userFrames.results"
+          v-if="imageDisplayToggle && store.state.smallImageCache"
+          :data="store.state.smallImageCache"
         />
         <ImageList
-          v-if="!imageDisplayToggle && userFrames"
-          :data="userFrames.results"
+          v-if="!imageDisplayToggle && store.state.smallImageCache"
+          :data="store.state.smallImageCache"
         />
       </div>
       <v-skeleton-loader
-        v-if="!userFrames"
+        v-if="!store.state.smallImageCache"
         type="card"
       />
       <div class="control-buttons">

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -131,14 +131,8 @@ const sessionNameExists = (name) => {
 	return uniqueDataSessions.value.some(session => session.name === name)
 }
 
-const saveLargeImages = async (data) => {
-	const largeImages = await data.results
-	store.commit('setLargeImages', largeImages)
-}
-
 const loadLargeImages = async (option) => {
-	const loadLargeImageUrl = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
-	await fetchApiCall({url: loadLargeImageUrl, method: 'GET', headers: authHeaders, successCallback: saveLargeImages, failCallback: handleError})
+	await store.dispatch('loadAndCacheImages', { option })
 }
 
 onMounted(() => {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -138,7 +138,7 @@ const saveLargeImages = async (data) => {
 
 const loadLargeImages = async (option) => {
 	const loadLargeImageUrl = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
-	await fetchApiCall({url: loadLargeImageUrl, method: 'GET', headers: authHeaders, successCallback: saveLargeImages})
+	await fetchApiCall({url: loadLargeImageUrl, method: 'GET', headers: authHeaders, successCallback: saveLargeImages, failCallback: handleError})
 }
 
 onMounted(() => {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -24,7 +24,6 @@ const loadUserImages = async (option) => {
 	isLoading.value = true
 	await store.dispatch('loadAndCacheImages', { option })
 	isLoading.value = false
-  
 }
 
 // boolean computed property used to disable the add to session button

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -13,6 +13,7 @@ const isPopupVisible = ref(false)
 const uniqueDataSessions = ref([])
 const newSessionName = ref('')
 const errorMessage = ref('')
+const isLoading = ref(true)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 const archiveUrl = store.state.datalabArchiveApiUrl
 
@@ -28,8 +29,10 @@ let userFrames = ref(null)
 
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async (option) => {
+	isLoading.value = true
 	const url = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
 	userFrames.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders})
+	isLoading.value = false
 }
 
 // boolean computed property used to disable the add to session button
@@ -132,7 +135,9 @@ const sessionNameExists = (name) => {
 }
 
 const loadLargeImages = async (option) => {
+	isLoading.value = true
 	await store.dispatch('loadAndCacheImages', { option })
+	isLoading.value = false
 }
 
 onMounted(() => {
@@ -146,14 +151,28 @@ onMounted(() => {
   <div class="container">
     <ProjectBar class="project-bar" />
     <div class="image-area h-screen">
-      <ImageCarousel
-        v-if="imageDisplayToggle && userFrames"
-        :data="userFrames.results"
-      />
-      <ImageList
-        v-if="!imageDisplayToggle && userFrames"
-        :data="userFrames.results"
-      />
+      <div
+        v-if="isLoading"
+        class="loading-indicator-container"
+      >
+        <v-progress-circular
+          indeterminate
+          model-value="20"
+          :size="50"
+          :width="9"
+        />
+      </div>
+
+      <div v-else>
+        <ImageCarousel
+          v-if="imageDisplayToggle && userFrames"
+          :data="userFrames.results"
+        />
+        <ImageList
+          v-if="!imageDisplayToggle && userFrames"
+          :data="userFrames.results"
+        />
+      </div>
       <v-skeleton-loader
         v-if="!userFrames"
         type="card"
@@ -224,28 +243,35 @@ onMounted(() => {
 </template>
 <style scoped>
 @media (min-width: 900px){
-    .container{
-        margin: 20px;
-        display: grid;
-        grid-template-columns: [col1-start] 1fr [col1-end col2-start] 80% [col2-end];
-        grid-template-rows: [row-start] 100% [row-end];
-    }
-    .project-bar{
-        display: flex;
-        grid-column-start: col1-start;
-        grid-column-end: col1-end;
-        grid-row-start: row-start;
-        grid-row-end: row-end;
-    }
-    .image-area{
-        grid-column-start: col2-start;
-        grid-column-end: col2-end;
-    }
+.container{
+    margin: 20px;
+    display: grid;
+    grid-template-columns: [col1-start] 1fr [col1-end col2-start] 80% [col2-end];
+    grid-template-rows: [row-start] 100% [row-end];
+}
+
+.loading-indicator-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+.project-bar{
+    display: flex;
+    grid-column-start: col1-start;
+    grid-column-end: col1-end;
+    grid-row-start: row-start;
+    grid-row-end: row-end;
+}
+.image-area{
+    grid-column-start: col2-start;
+    grid-column-end: col2-end;
+}
 }
 .control-buttons{
-    margin-top: 10px;
-    display: flex;
-    align-items: center;
-    float: right;
+margin-top: 10px;
+display: flex;
+align-items: center;
+float: right;
 }
 </style>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -134,7 +134,6 @@ const sessionNameExists = (name) => {
 const saveLargeImages = async (data) => {
 	const largeImages = await data.results
 	store.commit('setLargeImages', largeImages)
-	store.commit('setFirstLargeImage', largeImages[0].url)
 }
 
 const loadLargeImages = async (option) => {


### PR DESCRIPTION
## FEATURE: LARGE IMAGE DISPLAY

### Description


**Background**
We want the functionality for when a user selects a thumbnail to display its corresponding large image. The current implementation is not necessarily the long term one, but it works with the amount of data that we currently have. 

**Implementation**
When Project View first mounts, we call `loadLargeImages` which then uses the util api call. The success callback awaits for the `data.results`, which are objects with the images' metadata, and then these get stored in the store through `setLargeImages` mutation. I also have a `firstLargeImage` in the store which is to hardcode the first image so that when the user first loads the Project View, they can see the first large image. 

Now, here's the logic on how to display the selected thumbnail as a large image. First, in `handleThumbnailClick` we assign the value of `lastSelectedImage` 's basename (minus `-small`) to `smallImageBasename`. Then, in `getLargeImageSource` we access the store to get the array of objects of `largeImages` and find one whose basename (minus `-large`) matches that on `smallImageBaseName` and we get the url from that object. That url is then assigned to `largeImageSrc`.

In the template, the image source checks if there is a `largeImageSrc`. If there is, that's the source, if there isn't (i.e. the user just loaded the Project View page, then we get `firstLargeImage` from the store 


### Visuals
**If user is logged in, first image to load is the first one from the array. You can see that as user selects other thumbnail images, the corresponding large image is displayed**

https://github.com/LCOGT/datalab-ui/assets/54489472/98a417f4-cd41-42bc-a2dc-a29024631c6c

