### PR TITLE
Update/persist login credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "vue3-carousel": "^0.3.1",
         "vuetify": "^3.0.0-beta.0",
         "vuex": "^4.0.2",
+        "vuex-persistedstate": "^4.1.0",
         "webfontloader": "^1.0.0"
       },
       "devDependencies": {
@@ -10721,6 +10722,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/shvl": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.3.tgz",
+      "integrity": "sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==",
+      "deprecated": "older versions vulnerable to prototype pollution"
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -11941,6 +11948,27 @@
       },
       "peerDependencies": {
         "vue": "^3.0.2"
+      }
+    },
+    "node_modules/vuex-persistedstate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz",
+      "integrity": "sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "shvl": "^2.0.3"
+      },
+      "peerDependencies": {
+        "vuex": "^3.0 || ^4.0.0-rc"
+      }
+    },
+    "node_modules/vuex-persistedstate/node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "vue3-carousel": "^0.3.1",
     "vuetify": "^3.0.0-beta.0",
     "vuex": "^4.0.2",
+    "vuex-persistedstate": "^4.1.0",
     "webfontloader": "^1.0.0"
   },
   "devDependencies": {

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -9,12 +9,6 @@ const emit = defineEmits(['reloadSession'])
 let images = ref([])
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 
-const authHeaders = {
-	'Content-Type': 'application/json',
-	'Accept': 'application/json',
-	'Authorization': `Token ${store.getters['userData/authToken']}`,
-}
-
 const props = defineProps({
 	data: {
 		type: Object,
@@ -24,12 +18,12 @@ const props = defineProps({
 
 async function addOperation(operationDefinition) {
 	const url = dataSessionsUrl + props.data.id + '/operations/'
-	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, headers: authHeaders, successCallback: emit('reloadSession'), failCallback: handleError})
+	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
 const getImages = async () => {
 	const url = dataSessionsUrl + props.data.id
-	await fetchApiCall({url: url, method: 'GET', headers: authHeaders, successCallback: (data) => {images.value = data.input_data}, failCallback: handleError})
+	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {images.value = data.input_data}, failCallback: handleError})
 }
 
 onMounted(() => {

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -12,7 +12,7 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 const authHeaders = {
 	'Content-Type': 'application/json',
 	'Accept': 'application/json',
-	'Authorization': `Token ${store.state.authToken}`,
+	'Authorization': `Token ${store.getters['userData/authToken']}`,
 }
 
 const props = defineProps({

--- a/src/components/DeleteSessionDialog.vue
+++ b/src/components/DeleteSessionDialog.vue
@@ -8,12 +8,6 @@ const props = defineProps([ 'modelValue', 'deleteId'])
 const emit = defineEmits(['update:modelValue', 'reloadSession'])
 const store = useStore()
 
-const authHeaders = {
-	'Content-Type': 'application/json',
-	'Accept': 'application/json',
-	'Authorization': `Token ${store.getters['userData/authToken']}`,
-}
-
 let showSnackBar = ref(false)
 const datalabApiBaseUrl = store.state.datalabApiBaseUrl
 const dataSessionsUrl = datalabApiBaseUrl + 'datasessions/'
@@ -25,7 +19,7 @@ function closeDialog() {
 
 async function confirmDeleteSession() {
 	const url = dataSessionsUrl + props.deleteId
-	await fetchApiCall({url: url, method: 'DELETE', headers: authHeaders, successCallback: closeDialog, failCallback: () => {showSnackBar.value=true} })
+	await fetchApiCall({url: url, method: 'DELETE', successCallback: closeDialog, failCallback: () => {showSnackBar.value=true} })
 }
 </script>
 <template>

--- a/src/components/DeleteSessionDialog.vue
+++ b/src/components/DeleteSessionDialog.vue
@@ -11,7 +11,7 @@ const store = useStore()
 const authHeaders = {
 	'Content-Type': 'application/json',
 	'Accept': 'application/json',
-	'Authorization': `Token ${store.state.authToken}`,
+	'Authorization': `Token ${store.getters['userData/authToken']}`,
 }
 
 let showSnackBar = ref(false)

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -10,7 +10,7 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl
 const authHeaders = {
 	'Content-Type': 'application/json',
 	'Accept': 'application/json',
-	'Authorization': `Token ${store.state.authToken}`,
+	'Authorization': `Token ${store.getters['userData/authToken']}`,
 }
 
 const availableOperations = ref({})

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -7,19 +7,13 @@ const store = useStore()
 const emit = defineEmits(['closeWizard', 'addOperation'])
 const dataSessionsUrl = store.state.datalabApiBaseUrl
 
-const authHeaders = {
-	'Content-Type': 'application/json',
-	'Accept': 'application/json',
-	'Authorization': `Token ${store.getters['userData/authToken']}`,
-}
-
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 
 onMounted(async () => {
 	const url = dataSessionsUrl + 'available_operations/'
-	await fetchApiCall({url: url, method: 'GET', headers: authHeaders, successCallback: (data) => {availableOperations.value = data}, failCallback: handleError})
+	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {availableOperations.value = data}, failCallback: handleError})
 	if (Object.keys(availableOperations.value).length > 0){
 		selectedOperation.value = Object.keys(availableOperations.value)[0]
 	}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,14 @@
 import { createStore } from 'vuex'
+import userData from './modules/userData'
+import createPersistedState from 'vuex-persistedstate'
 
 export default createStore({
+	modules: {
+		userData
+	},
+	plugins: [createPersistedState({
+		paths: ['userData'],
+	})],
 	state() {
 		return {
 			selectedImages: [],
@@ -8,9 +16,6 @@ export default createStore({
 			datalabApiBaseUrl: '',
 			datalabArchiveApiUrl: '',
 			observationPortalUrl: '',
-			username: '',
-			authToken: '',
-			profile: [],
 			projects: []
 		}
 	},
@@ -43,18 +48,6 @@ export default createStore({
     
 		setObservationPortalUrl(state, url) {
 			state.observationPortalUrl = url
-		},
-
-		setUsername(state, username) {
-			state.username = username
-		},
-
-		setAuthToken(state, token) {
-			state.authToken = token
-		},
-
-		setUserProfile(state, profile) {
-			state.profile.push(profile)
 		},
 
 		setProjects(state, projects) {

--- a/src/store/modules/userData.js
+++ b/src/store/modules/userData.js
@@ -18,7 +18,6 @@ const actions = {
 	},
 
 	setAuthToken({ commit }, authToken) {
-		console.log('reached the userData store, setting auth token: ', authToken)
 		commit('authToken', authToken)
 	},
 

--- a/src/store/modules/userData.js
+++ b/src/store/modules/userData.js
@@ -1,0 +1,51 @@
+const state = {
+	username: '',
+	authToken: '',
+	profile: [],
+}
+
+// getters
+const getters = {
+	username: state => state.username,
+	authToken: state => state.authToken,
+	profile: state => state.profile
+}
+
+// actions
+const actions = {
+	setUsername({ commit }, username) {
+		commit('username', username)
+	},
+
+	setAuthToken({ commit }, authToken) {
+		console.log('reached the userData store, setting auth token: ', authToken)
+		commit('authToken', authToken)
+	},
+
+	setUserProfile({ commit }, userProfile) {
+		commit('userProfile', userProfile)
+	},
+}
+
+// mutations
+const mutations = {
+	username(state, username) {
+		state.username = username
+	},
+
+	authToken(state, token) {
+		state.authToken = token
+	},
+
+	userProfile(state, profile) {
+		state.profile.push(profile)
+	},
+}
+
+export default {
+	namespaced: true,
+	state,
+	getters,
+	actions,
+	mutations
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,8 +1,19 @@
+import store from '../store/index'
+
 // handles api requests for datasessions with configurable parameters and callback functions
-async function fetchApiCall({ url, method, body = null, headers, successCallback = null, failCallback = null }) {
+async function fetchApiCall({ url, method, body = null, header, successCallback = null, failCallback = null }) {
+
+	const defaultHeader = {
+		'Content-Type': 'application/json',
+		'Accept': 'application/json',
+	}
+	if(store.getters['userData/authToken']){
+		defaultHeader['Authorization'] = `Token ${store.getters['userData/authToken']}`
+	}
+
 	const config = {
 		method: method,
-		headers: headers,
+		headers: header ? header : defaultHeader,
 		body: body ? JSON.stringify(body) : null
 	}
 

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -15,7 +15,7 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 const authHeaders = {
 	'Content-Type': 'application/json',
 	'Accept': 'application/json',
-	'Authorization': `Token ${store.state.authToken}`,
+	'Authorization': `Token ${store.getters['userData/authToken']}`,
 }
 
 onMounted(() => {

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -12,12 +12,6 @@ const deleteSessionId = ref(-1)
 const showDeleteDialog = ref(false)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 
-const authHeaders = {
-	'Content-Type': 'application/json',
-	'Accept': 'application/json',
-	'Authorization': `Token ${store.getters['userData/authToken']}`,
-}
-
 onMounted(() => {
 	loadAllSessions()
 })
@@ -28,7 +22,7 @@ function deleteSession(id) {
 }
 
 async function loadAllSessions() {
-	await fetchApiCall({url: dataSessionsUrl, method: 'GET', headers: authHeaders, successCallback: (data) => {dataSessions.value = data.results}, failCallback: handleError})
+	await fetchApiCall({url: dataSessionsUrl, method: 'GET', successCallback: (data) => {dataSessions.value = data.results}, failCallback: handleError})
 }
 
 </script>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -19,7 +19,7 @@ const archiveUrl = store.state.datalabArchiveApiUrl
 const authHeaders = {
 	'Content-Type': 'application/json',
 	'Accept': 'application/json',
-	'Authorization': `Token ${store.state.authToken}`,
+	'Authorization': `Token ${store.getters['userData/authToken']}`,
 }
 
 // toggle for optional data viewing, controlled by a v-switch

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -16,12 +16,6 @@ const errorMessage = ref('')
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 const archiveUrl = store.state.datalabArchiveApiUrl
 
-const authHeaders = {
-	'Content-Type': 'application/json',
-	'Accept': 'application/json',
-	'Authorization': `Token ${store.getters['userData/authToken']}`,
-}
-
 // toggle for optional data viewing, controlled by a v-switch
 let imageDisplayToggle = ref(true)
 let userFrames = ref(null)
@@ -29,7 +23,7 @@ let userFrames = ref(null)
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async (option) => {
 	const url = option ? archiveUrl + 'frames/?' + option : archiveUrl + 'frames/'
-	userFrames.value = await fetchApiCall({url: url, method: 'GET', headers: authHeaders})
+	userFrames.value = await fetchApiCall({url: url, method: 'GET'})
 }
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {
@@ -53,7 +47,7 @@ const handleError = (error) => {
 // fetches session data from API and handles response or error using the callbacks
 const getDataSessions = async () => {
 	try {
-		await fetchApiCall({ url: dataSessionsUrl, method: 'GET', headers: authHeaders, successCallback: mapDataSessions, failCallback: handleError })
+		await fetchApiCall({ url: dataSessionsUrl, method: 'GET', successCallback: mapDataSessions, failCallback: handleError })
 	} catch (error) {
 		handleError(error)
 	}
@@ -64,7 +58,7 @@ const addImagesToExistingSession = async (session) => {
 	const sessionIdUrl = dataSessionsUrl + session.id + '/'
 	try {
 		// fetches existing session data
-		const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET', headers: authHeaders })
+		const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
 		const currentSessionData = currentSessionResponse.input_data
 
 		// merging existing and new image data
@@ -82,7 +76,7 @@ const addImagesToExistingSession = async (session) => {
 		}
 
 		// sending the PATCH request with the merged data
-		await fetchApiCall({ url: sessionIdUrl, method: 'PATCH', body: requestBody, headers: authHeaders })
+		await fetchApiCall({ url: sessionIdUrl, method: 'PATCH', body: requestBody })
 	} catch (error) {
 		console.error('Error importing images:', error)
 		handleError(error)
@@ -114,7 +108,7 @@ const createNewDataSession = async () => {
 	}
 	try {
 		// attempting a POST request for new session
-		await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody, headers: authHeaders })
+		await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody })
 
 		// resetting state an rerouting to DataSessions view upon successful creation of new session
 		isPopupVisible.value = false

--- a/src/views/RegistrationView.vue
+++ b/src/views/RegistrationView.vue
@@ -57,13 +57,8 @@ const storeUser = (user) => {
 
 const getUserProfile = async () => {
 	await authenticateUser ()
-	const authHeaders = {
-		'Content-Type': 'application/json',
-		'Accept': 'application/json',
-		'Authorization': `Token ${store.getters['userData/authToken']}`,
-	}
 	try {
-		await fetchApiCall({ url: store.state.observationPortalUrl + 'profile/', method: 'GET', headers: authHeaders, successCallback: storeUser, failCallback: handleError })
+		await fetchApiCall({ url: store.state.observationPortalUrl + 'profile/', method: 'GET', successCallback: storeUser, failCallback: handleError })
 	} catch (error) {
 		handleError(error)
 	}

--- a/src/views/RegistrationView.vue
+++ b/src/views/RegistrationView.vue
@@ -20,7 +20,7 @@ const rules = {
 const storeToken = (data) => {
 	const authToken = data.token
 	if (authToken) {
-		store.commit('setAuthToken', authToken)
+		store.dispatch('userData/setAuthToken', authToken)
 		return authToken
 	}
 }
@@ -49,19 +49,18 @@ const authenticateUser = async () => {
 }
 
 const storeUser = (user) => {
-	store.commit('setUsername', username.value)
-	store.commit('setUserProfile', user)
+	store.dispatch('userData/setUsername', username.value)
+	store.dispatch('userData/setUserProfile', user)
 	store.commit('setProjects', user.proposals)
 	router.push({ name: 'ProjectView' })
 }
 
 const getUserProfile = async () => {
 	await authenticateUser ()
-	const token = store.state.authToken
 	const authHeaders = {
 		'Content-Type': 'application/json',
 		'Accept': 'application/json',
-		'Authorization': `Token ${token}`,
+		'Authorization': `Token ${store.getters['userData/authToken']}`,
 	}
 	try {
 		await fetchApiCall({ url: store.state.observationPortalUrl + 'profile/', method: 'GET', headers: authHeaders, successCallback: storeUser, failCallback: handleError })


### PR DESCRIPTION
The site will now keep people logged in between page refreshes. It does this by storing the auth token in local storage through the vuex store and the package persisted state.

Changes:
- added npm package vuex-persistedstate
- added store module userData that is persisted and contains user profile and auth token
- added default header to fetchApi util and removed declarations of auth headers it replaces