### PR TITLE
Feature/redirect to datasession

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,12 @@ const routes = [
 		path: '/datasessions/',
 		name: 'DataSessions',
 		component: DataSessions,
+	},
+	{
+		path: '/datasessions/:sessionId',
+		name: 'DataSessionDetails',
+		component: DataSessions,
+		props: true
 	}
 ]
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,13 +15,7 @@ const routes = [
 		component: ProjectView
 	},
 	{
-		path: '/datasessions/',
-		name: 'DataSessions',
-		component: DataSessions,
-		props:true
-	},
-	{
-		path: '/datasessions/:sessionId',
+		path: '/datasessions/:sessionId?',
 		name: 'DataSessionDetails',
 		component: DataSessions,
 		props: true

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,13 +18,14 @@ const routes = [
 		path: '/datasessions/',
 		name: 'DataSessions',
 		component: DataSessions,
+		props:true
 	},
 	{
 		path: '/datasessions/:sessionId',
 		name: 'DataSessionDetails',
 		component: DataSessions,
 		props: true
-	}
+	},
 ]
 
 const router = createRouter({

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -4,9 +4,10 @@ import { useStore } from 'vuex'
 import { fetchApiCall, handleError } from '../utils/api'
 import DataSession from '@/components/DataSession.vue'
 import DeleteSessionDialog from '@/components/DeleteSessionDialog.vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 
 const router = useRouter()
+const route = useRoute()
 const store = useStore()
 const dataSessions = ref([])
 const tab = ref()
@@ -18,8 +19,13 @@ onBeforeMount(()=>{
 	if(!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
 })
 
-onMounted(() => {
-	loadAllSessions()
+onMounted(async () => {
+	await loadSessions()
+	if (route.params.sessionId) {
+		tab.value = Number(route.params.sessionId)
+	} else {
+		tab.value = dataSessions.value[0].id
+	}
 })
 
 function deleteSession(id) {
@@ -27,7 +33,7 @@ function deleteSession(id) {
 	showDeleteDialog.value = true
 }
 
-async function loadAllSessions() {
+async function loadSessions() {
 	await fetchApiCall({url: dataSessionsUrl, method: 'GET', successCallback: (data) => {dataSessions.value = data.results}, failCallback: handleError})
 }
 
@@ -71,7 +77,7 @@ async function loadAllSessions() {
         >
           <data-session
             :data="ds"
-            @reload-session="loadAllSessions()"
+            @reload-session="loadSessions()"
           />
         </v-window-item>
       </v-window>
@@ -79,7 +85,7 @@ async function loadAllSessions() {
     <delete-session-dialog
       v-model="showDeleteDialog"
       :delete-id="deleteSessionId"
-      @reload-session="loadAllSessions()"
+      @reload-session="loadSessions()"
     />
   </v-container>
 </template>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -24,9 +24,16 @@ onMounted(async () => {
 	// if user created or selected a specific datasession, load that tab
 	if (route.params.sessionId) {
 		tab.value = Number(route.params.sessionId)
-		// if user is navigating to just /datasessions then their first datasession loads
+		// if user is navigating to just /datasessions then their first datasession loads and adds /[first id] as params
 	} else {
-		tab.value = dataSessions.value[0].id
+		if (dataSessions.value.length > 0) {
+			const firstSessionId = dataSessions.value[0].id
+			tab.value = firstSessionId
+			router.replace({ name: 'DataSessionDetails', params: { sessionId: firstSessionId }})
+		} else {
+			console.log('no data sessions available to display')
+		}
+		
 	}
 })
 

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -21,8 +21,10 @@ onBeforeMount(()=>{
 
 onMounted(async () => {
 	await loadSessions()
+	// if user created or selected a specific datasession, load that tab
 	if (route.params.sessionId) {
 		tab.value = Number(route.params.sessionId)
+		// if user is navigating to just /datasessions then their first datasession loads
 	} else {
 		tab.value = dataSessions.value[0].id
 	}

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -37,6 +37,11 @@ onMounted(async () => {
 	}
 })
 
+function onTabChange(newSessionId) {
+	router.push({ name: 'DataSessionDetails', params: { sessionId: newSessionId }})
+}
+
+
 function deleteSession(id) {
 	deleteSessionId.value = id
 	showDeleteDialog.value = true
@@ -57,6 +62,7 @@ async function loadSessions() {
         next-icon="mdi-arrow-right-bold-box-outline"
         prev-icon="mdi-arrow-left-bold-box-outline"
         show-arrows
+        @update:model-value="onTabChange"
       >
         <v-tab
           v-for="ds in dataSessions"

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -42,7 +42,7 @@ function onTabChange(newSessionId) {
 }
 
 
-function deleteSession(id) {
+async function deleteSession(id) {
 	deleteSessionId.value = id
 	showDeleteDialog.value = true
 }

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -51,19 +51,15 @@ const handleError = (error) => {
 
 // fetches session data from API and handles response or error using the callbacks
 const getDataSessions = async () => {
-	try {
-		await fetchApiCall({ url: dataSessionsUrl, method: 'GET', successCallback: mapDataSessions, failCallback: handleError })
-	} catch (error) {
-		handleError(error)
-	}
+	await fetchApiCall({ url: dataSessionsUrl, method: 'GET', successCallback: mapDataSessions, failCallback: handleError })
 }
 
 // updates an existing session with selected images
 const addImagesToExistingSession = async (session) => {
 	const sessionIdUrl = dataSessionsUrl + session.id + '/'
-	try {
-		// fetches existing session data
-		const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
+	// fetches existing session data
+	const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
+	if (currentSessionResponse) {
 		const currentSessionData = currentSessionResponse.input_data
 
 		// merging existing and new image data
@@ -82,9 +78,8 @@ const addImagesToExistingSession = async (session) => {
 
 		// sending the PATCH request with the merged data
 		await fetchApiCall({ url: sessionIdUrl, method: 'PATCH', body: requestBody })
-	} catch (error) {
-		console.error('Error importing images:', error)
-		handleError(error)
+	} else {
+		handleError()
 	}
 }
 
@@ -92,7 +87,7 @@ const addImagesToExistingSession = async (session) => {
 const selectDataSession = (session) => {
 	isPopupVisible.value = false
 	addImagesToExistingSession(session)
-	router.push({ name: 'DataSessions' })
+	router.push({ name: 'DataSessionDetails', params: { sessionId: session.id } })
 }
 
 // handles creation of a new session 
@@ -110,17 +105,15 @@ const createNewDataSession = async () => {
 		'name': newSessionName.value,
 		'input_data': inputData 
 	}
-	try {
-		// attempting a POST request for new session
-		await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody })
 
-		// resetting state an rerouting to DataSessions view upon successful creation of new session
+	// attempting a POST request for new session
+	const response = await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody })
+	if (response) {
 		isPopupVisible.value = false
 		newSessionName.value = ''
 		errorMessage.value = ''
-		router.push({ name: 'DataSessions' })
-	} catch (error) {
-		console.error('Error creating new data session:', error)
+		router.push({ name: 'DataSessionDetails', params: { sessionId: response.id } })
+	} else {
 		errorMessage.value = 'Error creating new data session'
 	}
 }


### PR DESCRIPTION
## FEATURE: Redirecting user to specific data session

### Description

**Background:**
Users would be redirected to "localhost:8080/datasessions" without a specific session selected after either creating a new session or selecting a session to add images to. Now we redirect to a specific session or if they just enter "/datasessions" it takes them to the first one. 

**AND** got rid of unnecessary try catch blocks

**Implementation:**

- Rewrote the route for data sessions. Now we go to a session id and pass down props 
- In ProjectView, we pass down the session id as params when the user creates or selects a new datasession to add to
- In DataSessionView, we check if `route.params.sessionId` has a value. If it does, then we assign that value to the tab and the user will see that upon clicking their datasession in ProjectView. If it doesn't have a value, then we check if there are data sessions and if there are, then we `router.replace` and pass the first session id as params so the url becomes "localhost:8080/datasessions/[first id]". If the user enters "/datasessions" it'll automatically append the first session id. And lastly, if there aren't any datasessions, for now, we are just console logging "no data sessions available to display"


**Future notes (if relevant)**
- Change console log "no data sessions available to display" to something else. Perhaps reroute them to ProjectView? 

### Visuals

**Video of this working (check url)**

https://github.com/LCOGT/datalab-ui/assets/54489472/bd535138-de1c-4b37-b183-d0246868f49c


