### PR TITLE
Styling/datasession

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -28,13 +28,10 @@ async function addOperation(operationDefinition) {
 	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
-const displayImages = (data) => {
-	images.value = data.input_data
-}
 
 const getImages = async () => {
 	const url = dataSessionsUrl + props.data.id
-	await fetchApiCall({url: url, method: 'GET', successCallback: displayImages, failCallback: handleError})
+	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {images.value = data.input_data}, failCallback: handleError})
 }
 
 const calculateColumnSpan = (imageCount) => {

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -28,9 +28,20 @@ async function addOperation(operationDefinition) {
 	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
+const displayImages = (data) => {
+	images.value = data.input_data
+	console.log('images.value', images.value)
+}
+
 const getImages = async () => {
 	const url = dataSessionsUrl + props.data.id
-	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {images.value = data.input_data}, failCallback: handleError})
+	await fetchApiCall({url: url, method: 'GET', successCallback: displayImages, failCallback: handleError})
+}
+
+const calculateColumnSpan = (imageCount) => {
+	const imagesPerRow = 5
+	const columnsPerImage = Math.floor(12 / Math.min(imagesPerRow, imageCount))
+	return columnsPerImage
 }
 
 onMounted(() => {
@@ -39,31 +50,46 @@ onMounted(() => {
 
 </script>
 
+
 <template>
   <v-container class="d-lg-flex">
-    <v-row>
-      <v-col cols="9">
-        <v-carousel v-if="images.length">
-          <v-carousel-item
-            v-for="(image) in images"
-            :key="image.basename"
-            :src="image.source"
-            :alt="image.basename"
-            cover
-          />
-        </v-carousel>
-      </v-col>
+    <v-row v-if="images.length">
       <v-col
-        cols="3"
-        justify="center"
-        align="center"
+        v-for="image in images"
+        :key="image.basename"
+        :cols="calculateColumnSpan(images.length)"
       >
-        <!-- The operations bar list goes here -->
-        <operation-pipeline
-          :operations="data.operations"
-          @add-operation="addOperation"
-        />
+        <v-img
+          :src="image.source"
+          :alt="image.basename"
+          cover
+          aspect-ratio="1"
+        >
+          <!-- <template #placeholder>
+            <v-row
+              class="fill-height ma-0"
+              align="center"
+              justify="center"
+            >
+              <v-progress-circular
+                indeterminate
+                color="grey-lighten-5"
+              />
+            </v-row>
+          </template> -->
+        </v-img>
       </v-col>
     </v-row>
+    <v-col
+      cols="3"
+      justify="center"
+      align="center"
+    >
+      <!-- The operations bar list goes here -->
+      <operation-pipeline
+        :operations="data.operations"
+        @add-operation="addOperation"
+      />
+    </v-col>
   </v-container>
 </template>

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -35,7 +35,7 @@ const getImages = async () => {
 }
 
 const calculateColumnSpan = (imageCount) => {
-	const imagesPerRow = 5
+	const imagesPerRow = 4
 	const columnsPerImage = Math.floor(12 / Math.min(imagesPerRow, imageCount))
 	return columnsPerImage
 }

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -30,7 +30,6 @@ async function addOperation(operationDefinition) {
 
 const displayImages = (data) => {
 	images.value = data.input_data
-	console.log('images.value', images.value)
 }
 
 const getImages = async () => {


### PR DESCRIPTION
## STYLING: Displaying images as a grid 

### Description
**Background:**
After discussing in our design meeting, we agreed that images should be displayed in a grid system rather than a carousel

**Implementation:**
In the `Datasession` component, I added a `calculateColumnSpan` function to determine the number of columns in the grid system. This function calculates the number of columns each image should span to fit up to 4 images (subject to change) in a row on a 12 column grid (vuetify's limit, but we can change this later), without exceeding the total number of images. If there are fewer than 4 images, it adjusts so that the images can evenly spread across the grid. 
Important note: I left some commented out code cause there's a bug that has been fixed on a separate branch. The commented out code displays the `progress-circular` component from vuetify to display when images are loading. This commented out code will soon not be commented out (check next PR)

### Visuals
**Data Session grid view on desktop**
<img width="1728" alt="Screenshot 2024-02-12 at 11 54 41 AM" src="https://github.com/LCOGT/datalab-ui/assets/54489472/614d5c53-1988-42e5-92bf-2a6ee25e2a47">



**Data Session grid views on iPad**
![1F8A8E84-3313-4D47-936E-6FADE2B714ED](https://github.com/LCOGT/datalab-ui/assets/54489472/e6c83f86-e999-448e-baf3-4496bf7d1468)
![D1E6F297-C28F-4414-ABCA-8D113FE15D93](https://github.com/LCOGT/datalab-ui/assets/54489472/46444627-5cd9-49d6-b706-050de2e9246c)


