### PR TITLE
Fix/add images to datasession

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -28,14 +28,9 @@ async function addOperation(operationDefinition) {
 	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
-const displayImages = (data) => {
-	images.value = data.input_data
-	console.log('images.value', images.value)
-}
-
 const getImages = async () => {
 	const url = dataSessionsUrl + props.data.id
-	await fetchApiCall({url: url, method: 'GET', successCallback: displayImages, failCallback: handleError})
+	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => { images.value = data.input_data }, failCallback: handleError})
 }
 
 const calculateColumnSpan = (imageCount) => {
@@ -65,7 +60,7 @@ onMounted(() => {
           cover
           aspect-ratio="1"
         >
-          <!-- <template #placeholder>
+          <template #placeholder>
             <v-row
               class="fill-height ma-0"
               align="center"
@@ -76,7 +71,7 @@ onMounted(() => {
                 color="grey-lighten-5"
               />
             </v-row>
-          </template> -->
+          </template>
         </v-img>
       </v-col>
     </v-row>

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -59,20 +59,7 @@ onMounted(() => {
           :alt="image.basename"
           cover
           aspect-ratio="1"
-        >
-          <template #placeholder>
-            <v-row
-              class="fill-height ma-0"
-              align="center"
-              justify="center"
-            >
-              <v-progress-circular
-                indeterminate
-                color="grey-lighten-5"
-              />
-            </v-row>
-          </template>
-        </v-img>
+        />
       </v-col>
     </v-row>
     <v-col

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -39,7 +39,7 @@ const getImages = async () => {
 }
 
 const calculateColumnSpan = (imageCount) => {
-	const imagesPerRow = 5
+	const imagesPerRow = 4
 	const columnsPerImage = Math.floor(12 / Math.min(imagesPerRow, imageCount))
 	return columnsPerImage
 }

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -61,16 +61,14 @@ const addImagesToExistingSession = async (session) => {
 	const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
 	if (currentSessionResponse) {
 		const currentSessionData = currentSessionResponse.input_data
-
 		// merging existing and new image data
 		// this is temporary since the backend has to be updated to handle this
 		// remove this when backend gets updated
 		const selectedImages = store.state.selectedImages
 		const inputData = [...currentSessionData, ...selectedImages.map(image => ({
-			'source': image.image,
-			'basename': image.basefile_name
+			'source': image.url,
+			'basename': image.basename
 		}))]
-
 		const requestBody = {
 			'name': session.name,
 			'input_data': inputData


### PR DESCRIPTION
## FIX: Adding images to existing Data Sessions
### Description
**Background:**
There was a bug where we couldn't add images to existing data sessions because the structure of the keys from images objects changed

**Implementation:**
Fairly simple implementation. In `addImagesToExistingSession` found in Project View, I changed the `source` and `basename` under `inputData` to `image.url` and `image.basename`, respectively, because we were sending empty objects. Now we can add images to existing data sessions : ) 