### PR TITLE
Chore/basename to backend

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -4,18 +4,17 @@ import OperationPipeline from './OperationPipeline.vue'
 import { fetchApiCall, handleError } from '../utils/api'
 import { useStore } from 'vuex'
 
+const store = useStore()
+const emit = defineEmits(['reloadSession'])
+let images = ref([])
+const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
+
 const props = defineProps({
 	data: {
 		type: Object,
 		required: true
 	}
 })
-
-const store = useStore()
-const emit = defineEmits(['reloadSession'])
-let images = ref([])
-const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
-
 
 async function addOperation(operationDefinition) {
 	const url = dataSessionsUrl + props.data.id + '/operations/'
@@ -50,7 +49,6 @@ onMounted(() => {
 })
 
 </script>
-
 
 <template>
   <v-container class="d-lg-flex">

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -29,13 +29,18 @@ async function addOperation(operationDefinition) {
 	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
+const saveImages = (data) => {
+	const results = data.results
+	images.value = [...images.value, ...results]
+}
+
 const getImages = async () => {
 	const responseData = props.data
 	const inputData = responseData.input_data
 	for (const data of inputData) {
 		const basename = data.basename
 		const url =  `https://datalab-archive.photonranch.org/frames/?basename_exact=${basename}-small`
-		await fetchApiCall({url: url, method: 'GET', successCallback: (data) => { images.value.push(data.results) }, failCallback: handleError})
+		await fetchApiCall({url: url, method: 'GET', successCallback: saveImages , failCallback: handleError})
 	}
 }
 
@@ -57,12 +62,12 @@ onMounted(() => {
     <v-row v-if="images.length">
       <v-col
         v-for="image of images"
-        :key="image[0].basename"
+        :key="image.basename"
         :cols="calculateColumnSpan(images.length)"
       >
         <v-img
-          :src="image[0].url"
-          :alt="image[0].basename"
+          :src="image.url"
+          :alt="image.basename"
           cover
           aspect-ratio="1"
         />

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -4,17 +4,18 @@ import OperationPipeline from './OperationPipeline.vue'
 import { fetchApiCall, handleError } from '../utils/api'
 import { useStore } from 'vuex'
 
-const store = useStore()
-const emit = defineEmits(['reloadSession'])
-let images = ref([])
-const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
-
 const props = defineProps({
 	data: {
 		type: Object,
 		required: true
 	}
 })
+
+const store = useStore()
+const emit = defineEmits(['reloadSession'])
+let images = ref([])
+const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
+
 
 async function addOperation(operationDefinition) {
 	const url = dataSessionsUrl + props.data.id + '/operations/'
@@ -29,8 +30,13 @@ async function addOperation(operationDefinition) {
 }
 
 const getImages = async () => {
-	const url = dataSessionsUrl + props.data.id
-	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {images.value = data.input_data}, failCallback: handleError})
+	const responseData = props.data
+	const inputData = responseData.input_data
+	for (const data of inputData) {
+		const basename = data.basename
+		const url =  `https://datalab-archive.photonranch.org/frames/?basename_exact=${basename}-small`
+		await fetchApiCall({url: url, method: 'GET', successCallback: (data) => { images.value.push(data.results) }, failCallback: handleError})
+	}
 }
 
 const calculateColumnSpan = (imageCount) => {
@@ -50,13 +56,13 @@ onMounted(() => {
   <v-container class="d-lg-flex">
     <v-row v-if="images.length">
       <v-col
-        v-for="image in images"
-        :key="image.basename"
+        v-for="image of images"
+        :key="image[0].basename"
         :cols="calculateColumnSpan(images.length)"
       >
         <v-img
-          :src="image.source"
-          :alt="image.basename"
+          :src="image[0].url"
+          :alt="image[0].basename"
           cover
           aspect-ratio="1"
         />

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -28,13 +28,20 @@ async function addOperation(operationDefinition) {
 	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
+const saveImages = (data) => {
+	const results = data.results
+	if (results.length) {
+		images.value.push(data.results[0])
+	}
+}
+
 const getImages = async () => {
 	const responseData = props.data
 	const inputData = responseData.input_data
 	for (const data of inputData) {
 		const basename = data.basename
 		const url =  `https://datalab-archive.photonranch.org/frames/?basename_exact=${basename}-small`
-		await fetchApiCall({url: url, method: 'GET', successCallback: (data) => { images.value.push(data.results) }, failCallback: handleError})
+		await fetchApiCall({url: url, method: 'GET', successCallback: saveImages, failCallback: handleError})
 	}
 }
 
@@ -55,12 +62,12 @@ onMounted(() => {
     <v-row v-if="images.length">
       <v-col
         v-for="image of images"
-        :key="image[0].basename"
+        :key="image.basename"
         :cols="calculateColumnSpan(images.length)"
       >
         <v-img
-          :src="image[0].url"
-          :alt="image[0].basename"
+          :src="image.url"
+          :alt="image.basename"
           cover
           aspect-ratio="1"
         />

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -40,7 +40,7 @@ const getImages = async () => {
 	for (const data of inputData) {
 		const basename = data.basename
 		const url =  `https://datalab-archive.photonranch.org/frames/?basename_exact=${basename}-small`
-		await fetchApiCall({url: url, method: 'GET', successCallback: saveImages , failCallback: handleError})
+		await fetchApiCall({url: url, method: 'GET', successCallback: saveImages, failCallback: handleError})
 	}
 }
 

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -29,18 +29,13 @@ async function addOperation(operationDefinition) {
 	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
 }
 
-const saveImages = (data) => {
-	const results = data.results
-	images.value = [...images.value, ...results]
-}
-
 const getImages = async () => {
 	const responseData = props.data
 	const inputData = responseData.input_data
 	for (const data of inputData) {
 		const basename = data.basename
 		const url =  `https://datalab-archive.photonranch.org/frames/?basename_exact=${basename}-small`
-		await fetchApiCall({url: url, method: 'GET', successCallback: saveImages, failCallback: handleError})
+		await fetchApiCall({url: url, method: 'GET', successCallback: (data) => { images.value.push(data.results) }, failCallback: handleError})
 	}
 }
 
@@ -62,12 +57,12 @@ onMounted(() => {
     <v-row v-if="images.length">
       <v-col
         v-for="image of images"
-        :key="image.basename"
+        :key="image[0].basename"
         :cols="calculateColumnSpan(images.length)"
       >
         <v-img
-          :src="image.url"
-          :alt="image.basename"
+          :src="image[0].url"
+          :alt="image[0].basename"
           cover
           aspect-ratio="1"
         />

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -66,8 +66,8 @@ const addImagesToExistingSession = async (session) => {
 		// remove this when backend gets updated
 		const selectedImages = store.state.selectedImages
 		const inputData = [...currentSessionData, ...selectedImages.map(image => ({
-			'source': image.url,
-			'basename': image.basename
+			'source': 'archive',
+			'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
 		}))]
 		const requestBody = {
 			'name': session.name,
@@ -82,10 +82,11 @@ const addImagesToExistingSession = async (session) => {
 }
 
 // closes popup, invokes addImagesToExistingSession, and reroutes user to DataSessions view
-const selectDataSession = (session) => {
+const selectDataSession = async (session) => {
 	isPopupVisible.value = false
-	addImagesToExistingSession(session)
+	await addImagesToExistingSession(session)
 	router.push({ name: 'DataSessionDetails', params: { sessionId: session.id } })
+
 }
 
 // handles creation of a new session 
@@ -96,8 +97,8 @@ const createNewDataSession = async () => {
 	}
 	const selectedImages = store.state.selectedImages
 	const inputData = selectedImages.map(image => ({
-		'source': image.url,
-		'basename': image.basename
+		'source': 'archive',
+		'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
 	}))
 	const requestBody = { 
 		'name': newSessionName.value,


### PR DESCRIPTION
## CHORE: Sending only basename to backend instead of image url

### Description
**Background:**
Jon brought to our attention that we should only send the basename to the backend and the `source` should be where to point at.

**Implementation:**
In `ProjectView` where the user can create a new data session or add to a data session, I changed the source and the basename. The basename also gets rid of `-small` or `-large` to send the true basename to the backend. 
In the `DataSession` component, we use the  props that are passed down from `DataSessionView` and loop through the `inputData`. From here, we make an api request to get the image urls by using the basename and appending `-small` since we currently only need the small images. 
I also changed the successCallback to push the `data.results` to `images.value`


### Visuals

**Video of everything working as normal : )**


https://github.com/LCOGT/datalab-ui/assets/54489472/3dccd2e8-3adf-4908-926a-4f8ae4c88ee6




