### PR TITLE
Styling/style datasession

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -47,7 +47,7 @@ onMounted(() => {
 
 
 <template>
-  <v-container class="d-lg-flex">
+  <v-container class="d-lg-flex ds-container">
     <v-row v-if="images.length">
       <v-col
         v-for="image in images"
@@ -75,3 +75,9 @@ onMounted(() => {
     </v-col>
   </v-container>
 </template>
+
+<style scoped lang="scss">
+.ds-container {
+  background-color: $metal;
+}
+</style>

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -90,5 +90,6 @@ onMounted(() => {
 <style scoped lang="scss">
 .ds-container {
   background-color: $metal;
+  display:flex;
 }
 </style>

--- a/src/components/OperationPipeline.vue
+++ b/src/components/OperationPipeline.vue
@@ -103,4 +103,32 @@ function operationBtnColor(index) {
   background-color: $light-gray;
   color: $metal;
 }
+@media (max-width: 1200px) {
+  .operations {
+    font-size: 1.3rem;
+  }
+  .addop_button {
+    font-size: 1rem;
+    height: 5vh;
+  }
+  .operation_button {
+    width: 13vw;
+    height: 4.5vh;
+    font-size: 0.8rem;
+  }
+}
+@media (max-width: 900px) {
+  .operations {
+    font-size: 1.2rem;
+  }
+  .addop_button {
+    font-size: 0.9rem;
+    height: 4vh;
+  }
+  .operation_button {
+    width: 15vw;
+    height: 3vh;
+    font-size: 0.7rem;
+  }
+}
 </style>

--- a/src/components/OperationPipeline.vue
+++ b/src/components/OperationPipeline.vue
@@ -25,10 +25,10 @@ function selectOperation(index) {
 
 function operationBtnColor(index) {
 	if(index == selectedOperation.value){
-		return 'indigo-lighten-1'
+		return 'selected'
 	}
 	else {
-		return 'light-grey-darken-1'
+		return 'not-selected'
 	}
 }
 
@@ -46,8 +46,9 @@ function operationBtnColor(index) {
     class="mb-2"
   >
     <v-btn
-      :color="operationBtnColor(index)"
+      :class="operationBtnColor(index)"
       variant="outlined"
+      class="operation_button"
       @click="selectOperation(index)"
     >
       {{ index }}: {{ operation.name }}
@@ -85,8 +86,21 @@ function operationBtnColor(index) {
   font-size: 1.3rem;
   align-content: center;
   background-color: $light-blue;
-  opacity: calc(1);
   font-weight: 700;
   color: white;
+}
+.operation_button {
+  width: 12rem;
+  height: 3rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  border-style: none;
+}
+.selected {
+  background-color:$light-blue
+}
+.not-selected{
+  background-color: $light-gray;
+  color: $metal;
 }
 </style>

--- a/src/components/OperationPipeline.vue
+++ b/src/components/OperationPipeline.vue
@@ -34,7 +34,9 @@ function operationBtnColor(index) {
 
 </script>
 <template>
-  <h3>Operations</h3>
+  <h3 class="operations">
+    OPERATIONS
+  </h3>
   <v-divider class="mb-6" />
   <v-row
     v-for="(operation, index) in operations"
@@ -54,7 +56,7 @@ function operationBtnColor(index) {
   <v-divider class="mb-4 mt-4" />
   <v-btn
     variant="flat"
-    color="indigo-darken-2"
+    class="addop_button"
   >
     Add Operation
     <v-dialog
@@ -70,3 +72,21 @@ function operationBtnColor(index) {
     </v-dialog>
   </v-btn>
 </template>
+
+<style scoped lang="scss">
+.operations {
+  color: $tan;
+  letter-spacing: 0.05rem;
+  font-size: 2rem;
+}
+.addop_button {
+  width: 16rem;
+  height: 4rem;
+  font-size: 1.3rem;
+  align-content: center;
+  background-color: $light-blue;
+  opacity: calc(1);
+  font-weight: 700;
+  color: white;
+}
+</style>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -42,7 +42,6 @@ function onTabChange(newSessionId) {
 	router.push({ name: 'DataSessionDetails', params: { sessionId: newSessionId }})
 }
 
-
 async function deleteSession(id) {
 	deleteSessionId.value = id
 	showDeleteDialog.value = true
@@ -68,7 +67,6 @@ function tabColor(index) {
 		return 'not-selected'
 	}
 }
-
 
 </script>
 

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -14,6 +14,7 @@ const tab = ref()
 const deleteSessionId = ref(-1)
 const showDeleteDialog = ref(false)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
+const selectedTab = ref(-1)
 
 onBeforeMount(()=>{
 	if(!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
@@ -51,6 +52,24 @@ async function loadSessions() {
 	await fetchApiCall({url: dataSessionsUrl, method: 'GET', successCallback: (data) => {dataSessions.value = data.results}, failCallback: handleError})
 }
 
+function selectTab(index) {
+	if (index == selectedTab.value) {
+		selectedTab.value = -1
+	}
+	else {
+		selectedTab.value = index
+	}
+}
+
+function tabColor(index) {
+	if (dataSessions.value[index] && tab.value === dataSessions.value[index].id) {
+		return 'selected'
+	} else {
+		return 'not-selected'
+	}
+}
+
+
 </script>
 
 <template>
@@ -58,29 +77,32 @@ async function loadSessions() {
     <v-card>
       <v-tabs 
         v-model="tab"
-        bg-color="indigo"
+        class="tabs"
         next-icon="mdi-arrow-right-bold-box-outline"
         prev-icon="mdi-arrow-left-bold-box-outline"
         show-arrows
         @update:model-value="onTabChange"
       >
         <v-tab
-          v-for="ds in dataSessions"
+          v-for="(ds, index) in dataSessions"
           :key="ds.id"
           :value="ds.id"
-          class="pr-0"
+          :class="tabColor(index)"
+          class="pr-0 tab"
+          @click="selectTab(index)"
         >
           {{ ds.name }}
           <v-btn
             variant="text"
             icon="mdi-close"
-            color="grey-darken-1"
+            class="tab_button"
             @click="deleteSession(ds.id)"
           />
         </v-tab>
         <v-btn
           variant="plain"
           icon="mdi-plus-box"
+          class="tab_button"
           @click="router.push({ name: 'ProjectView' })"
         />
       </v-tabs>
@@ -104,3 +126,29 @@ async function loadSessions() {
     />
   </v-container>
 </template>
+
+<style scoped lang="scss">
+.tabs {
+  background-color: $metal;
+  border-bottom: 0.1rem solid $tan;
+}
+.tab {
+  font-size: 1.2rem;
+  text-decoration: none;
+  color: $tan;
+  font-weight: 600;
+  background-color: $metal;
+}
+.tab_button {
+  color: $tan;
+  text-decoration: none;
+  margin: 0 0.5rem;
+}
+.selected { 
+  background-color: $light-blue;
+  color: white;
+}
+.not-selected {
+  background-color: $metal;
+}
+</style>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -151,4 +151,12 @@ function tabColor(index) {
 .not-selected {
   background-color: $metal;
 }
+@media (max-width: 1200px) {
+  .tab {
+    font-size: 0.85rem;
+  }
+  .tab_button {
+    margin: 0;
+  }
+}
 </style>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -96,6 +96,7 @@ function tabColor(index) {
             variant="text"
             icon="mdi-close"
             class="tab_button"
+            :class="tabColor(index)"
             @click="deleteSession(ds.id)"
           />
         </v-tab>


### PR DESCRIPTION
## STYLING: Styled Data Session and made it tablet friendly

### Description
**Background:**
Data Sessions view needed styling to match Project View. We still need to style the wizard and the pop ups, but that's for another story

**Implementation:**
Added a bit of logic to make some classes dynamic to change the tabs colors. But primarily, the changes were styling.

### Visuals
**Video of Data Session view on desktop**

https://github.com/LCOGT/datalab-ui/assets/54489472/fa8bc5f6-80ea-47ec-a651-17825572fa34

**Screenshot of vertical iPad**
![AA967ADE-A28D-4A6F-8187-71F0858C4AC3](https://github.com/LCOGT/datalab-ui/assets/54489472/f63fbc76-5413-4ec8-8625-28531a95de94)



**Screenshot of landscape iPad**

![6671FD10-B0A4-4C1B-98F1-66D5253DADA8](https://github.com/LCOGT/datalab-ui/assets/54489472/f52d58f0-46d7-406e-bbfe-c4bc04cde367)



