### PR TITLE
Feature/wizard image selection

### DIFF
--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -18,10 +18,8 @@ const props = defineProps({
 
 async function addOperation(operationDefinition) {
 	const url = dataSessionsUrl + props.data.id + '/operations/'
-	//TODO: Remove this once we have the ability to select images in the wizard
 	if ('input_files' in operationDefinition.input_data){
-		operationDefinition.input_data.input_files = structuredClone(images.value)
-		for (const image of operationDefinition.input_data.input_files){
+		for (const image of operationDefinition.input_data.input_files) {
 			image.source = 'archive'
 		}
 	}

--- a/src/components/DataSession.vue
+++ b/src/components/DataSession.vue
@@ -81,6 +81,7 @@ onMounted(() => {
       <!-- The operations bar list goes here -->
       <operation-pipeline
         :operations="data.operations"
+        :images="images"
         @add-operation="addOperation"
       />
     </v-col>

--- a/src/components/OperationPipeline.vue
+++ b/src/components/OperationPipeline.vue
@@ -8,6 +8,10 @@ defineProps({
 	operations: {
 		type: Array,
 		required: true
+	},
+	images: {
+		type: Array,
+		required: true
 	}
 })
 
@@ -67,6 +71,7 @@ function operationBtnColor(index) {
       transition="dialog-bottom-transition"
     >
       <operation-wizard
+        :images="images"
         @close-wizard="showWizardDialog = false"
         @add-operation="emit('addOperation', $event); showWizardDialog = false;"
       />

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -73,7 +73,7 @@ const goForwardText = computed(() => {
 		return 'Configure Operation'
 	}
 	else {
-		return 'Add Operation'
+		return 'Add Operationzzz'
 	}
 })
 
@@ -95,7 +95,10 @@ function goForward() {
 		displayImages.value = false
 		let operationDefinition = {
 			'name': selectedOperation.value,
-			'input_data': selectedOperationInput.value
+			'input_data': {
+				...selectedOperationInput.value,
+				'input_files': selectedDataSessionImages.value
+			}
 		}
 		emit('addOperation', operationDefinition)
 	}

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -235,6 +235,7 @@ const handleThumbnailClick = (item) => {
   max-width: 20%; 
   height: auto; 
   box-sizing: border-box; 
+  cursor: pointer;
 }
 .selected-image {
   border: 0.3rem solid $dark-green;

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -10,6 +10,7 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
+const selectedDSImages = ref([])
 
 let displayImages = ref(false)
 
@@ -100,11 +101,19 @@ function goForward() {
 	}
 }
 
-
 const calculateColumnSpan = (imageCount) => {
 	const imagesPerRow = 6
 	const columnsPerImage = Math.floor(12 / Math.min(imagesPerRow, imageCount))
 	return columnsPerImage
+}
+
+const handleClick = (item) => {
+	const index = selectedDSImages.value.findIndex(selectedImage => selectedImage.basename === item.basename)
+	if (index === -1) {
+		selectedDSImages.value.push(item)
+	} else {
+		selectedDSImages.value.splice(index, 1)
+	}
 }
 
 </script>
@@ -180,8 +189,10 @@ const calculateColumnSpan = (imageCount) => {
         <v-img
           :src="image.url"
           :alt="image.basename"
+          :class="{ 'selected-image': selectedDSImages.some(selectedImage => selectedImage.basename === image.basename) }"
           cover
           aspect-ratio="1"
+          @click="handleClick(image)"
         />
       </v-col>
     </v-row>
@@ -213,5 +224,8 @@ const calculateColumnSpan = (imageCount) => {
 .images-container {
   margin: -1rem 2rem;
   display: flex;
+}
+.selected-image {
+  border: 0.3rem solid $dark-green;
 }
 </style>

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -44,6 +44,7 @@ function selectOperation(name) {
 }
 
 function goBack() {
+	displayImages.value = false
 	if (page.value == 'select') {
 		emit('closeWizard')
 	}
@@ -163,7 +164,10 @@ const calculateColumnSpan = (imageCount) => {
         </v-row>
       </v-card-text>
     </v-slide-y-reverse-transition>
-    <v-row v-if="images.length && displayImages == true">
+    <v-row
+      v-if="images.length && displayImages == true"
+      class="wizard-images"
+    >
       <v-col
         v-for="image of images"
         :key="image.basename"
@@ -196,3 +200,9 @@ const calculateColumnSpan = (imageCount) => {
     </v-card-actions>
   </v-card>
 </template>
+
+<style scoped lang="scss">
+.wizard-images {
+  margin: -1rem 1rem;
+}
+</style>

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed, defineEmits } from 'vue'
+import { ref, onMounted, computed, defineEmits, defineProps } from 'vue'
 import { fetchApiCall, handleError } from '../utils/api'
 import { useStore } from 'vuex'
 
@@ -10,6 +10,15 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
+
+let displayImages = ref(false)
+
+defineProps({
+	images: {
+		type: Array,
+		required: true
+	}
+})
 
 onMounted(async () => {
 	const url = dataSessionsUrl + 'available_operations/'
@@ -78,14 +87,23 @@ const wizardTitle = computed(() => {
 function goForward() {
 	if (page.value == 'select') {
 		page.value = 'configure'
+		displayImages.value = true
 	}
 	else {
+		displayImages.value = false
 		let operationDefinition = {
 			'name': selectedOperation.value,
 			'input_data': selectedOperationInput.value
 		}
 		emit('addOperation', operationDefinition)
 	}
+}
+
+
+const calculateColumnSpan = (imageCount) => {
+	const imagesPerRow = 6
+	const columnsPerImage = Math.floor(12 / Math.min(imagesPerRow, imageCount))
+	return columnsPerImage
 }
 
 </script>
@@ -145,6 +163,20 @@ function goForward() {
         </v-row>
       </v-card-text>
     </v-slide-y-reverse-transition>
+    <v-row v-if="images.length && displayImages == true">
+      <v-col
+        v-for="image of images"
+        :key="image.basename"
+        :cols="calculateColumnSpan(images.length)"
+      >
+        <v-img
+          :src="image.url"
+          :alt="image.basename"
+          cover
+          aspect-ratio="1"
+        />
+      </v-col>
+    </v-row>
     <v-card-actions>
       <v-spacer />
       <v-btn

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -73,7 +73,7 @@ const goForwardText = computed(() => {
 		return 'Configure Operation'
 	}
 	else {
-		return 'Add Operationzzz'
+		return 'Add Operation'
 	}
 })
 

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -10,7 +10,7 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
-const selectedDSImages = ref([])
+const selectedDataSessionImages = ref([])
 
 let displayImages = ref(false)
 
@@ -108,11 +108,11 @@ const calculateColumnSpan = (imageCount) => {
 }
 
 const handleThumbnailClick = (item) => {
-	const index = selectedDSImages.value.findIndex(selectedImage => selectedImage.basename === item.basename)
+	const index = selectedDataSessionImages.value.findIndex(selectedImage => selectedImage.basename === item.basename)
 	if (index === -1) {
-		selectedDSImages.value.push(item)
+		selectedDataSessionImages.value.push(item)
 	} else {
-		selectedDSImages.value.splice(index, 1)
+		selectedDataSessionImages.value.splice(index, 1)
 	}
 }
 
@@ -189,7 +189,7 @@ const handleThumbnailClick = (item) => {
         <v-img
           :src="image.url"
           :alt="image.basename"
-          :class="{ 'selected-image': selectedDSImages.some(selectedImage => selectedImage.basename === image.basename) }"
+          :class="{ 'selected-image': selectedDataSessionImages.some(selectedImage => selectedImage.basename === image.basename) }"
           cover
           aspect-ratio="1"
           @click="handleThumbnailClick(image)"

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -105,9 +105,9 @@ function goForward() {
 }
 
 const calculateColumnSpan = (imageCount) => {
-	const imagesPerRow = 6
-	const columnsPerImage = Math.floor(12 / Math.min(imagesPerRow, imageCount))
-	return columnsPerImage
+	const imagesPerRow = 5
+	const totalColumns = Math.floor(12 / Math.min(imagesPerRow, imageCount))
+	return totalColumns
 }
 
 const handleThumbnailClick = (item) => {
@@ -120,6 +120,7 @@ const handleThumbnailClick = (item) => {
 }
 
 </script>
+
 <template>
   <v-card>
     <v-toolbar
@@ -160,45 +161,41 @@ const handleThumbnailClick = (item) => {
         v-show="page == 'configure'"
         class="wizard-card"
       >
-        <v-row
+        <div
           v-for="(inputDescription, inputKey) in selectedOperationInputs"
           :key="inputKey"
         >
-          <p
-            v-if="inputDescription.type == 'file'"
-            class="mt-4 mb-4"
-          >
-            {{ inputKey }}: Insert a filepicker widget for {{ inputDescription.name }}
-          </p>
           <v-text-field
-            v-if="inputDescription.type != 'file'"
+            v-if="inputDescription.type !== 'file'"
             v-model="selectedOperationInput[inputKey]"
             :label="inputDescription.name"
             :type="inputDescription.type"
+            class="operation-input"
           />
-        </v-row>
+          <div
+            v-else-if="inputDescription.type == 'file'"
+            class="images-container"
+          >
+            <v-col
+              v-for="image in images"
+              :key="image.basename"
+              :cols="calculateColumnSpan(images.length)"
+              class="wizard-images"
+            >
+              <v-img
+                :src="image.url"
+                :alt="image.basename"
+                cover
+                aspect-ratio="1"
+                :class="{ 'selected-image': selectedDataSessionImages.some(selectedImage => selectedImage.basename === image.basename) }"
+                @click="handleThumbnailClick(image)"
+              />
+            </v-col>
+          </div>
+        </div>
       </v-card-text>
     </v-slide-y-reverse-transition>
-    <v-row
-      v-if="images.length && displayImages == true"
-      class="images-container"
-    >
-      <v-col
-        v-for="image of images"
-        :key="image.basename"
-        :cols="calculateColumnSpan(images.length)"
-        class="wizard-images"
-      >
-        <v-img
-          :src="image.url"
-          :alt="image.basename"
-          :class="{ 'selected-image': selectedDataSessionImages.some(selectedImage => selectedImage.basename === image.basename) }"
-          cover
-          aspect-ratio="1"
-          @click="handleThumbnailClick(image)"
-        />
-      </v-col>
-    </v-row>
+
     <v-card-actions>
       <v-spacer />
       <v-btn
@@ -221,14 +218,29 @@ const handleThumbnailClick = (item) => {
 
 <style scoped lang="scss">
 .wizard-card {
-  height: 5vh;
-  width: 20%;
+  width: 100%; 
+  display: flex;
+  flex-direction: column-reverse;
 }
 .images-container {
-  margin: -1rem 2rem;
   display: flex;
+  flex-wrap: wrap; 
+  justify-content: flex-start; 
+  width: 100%; 
+  margin-bottom: 50vw; 
+  padding-left: 2rem; 
+  padding-right: 2rem; 
+}
+.wizard-images {
+  max-width: 20%; 
+  height: auto; 
+  box-sizing: border-box; 
 }
 .selected-image {
   border: 0.3rem solid $dark-green;
+}
+.operation-input {
+  width: 10vw;
+  margin-bottom: 1rem;
 }
 </style>

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -144,7 +144,10 @@ const calculateColumnSpan = (imageCount) => {
       </v-row>
     </v-card-text>
     <v-slide-y-reverse-transition hide-on-leave>
-      <v-card-text v-show="page == 'configure'">
+      <v-card-text
+        v-show="page == 'configure'"
+        class="wizard-card"
+      >
         <v-row
           v-for="(inputDescription, inputKey) in selectedOperationInputs"
           :key="inputKey"
@@ -166,12 +169,13 @@ const calculateColumnSpan = (imageCount) => {
     </v-slide-y-reverse-transition>
     <v-row
       v-if="images.length && displayImages == true"
-      class="wizard-images"
+      class="images-container"
     >
       <v-col
         v-for="image of images"
         :key="image.basename"
         :cols="calculateColumnSpan(images.length)"
+        class="wizard-images"
       >
         <v-img
           :src="image.url"
@@ -202,7 +206,12 @@ const calculateColumnSpan = (imageCount) => {
 </template>
 
 <style scoped lang="scss">
-.wizard-images {
-  margin: -1rem 1rem;
+.wizard-card {
+  height: 5vh;
+  width: 20%;
+}
+.images-container {
+  margin: -1rem 2rem;
+  display: flex;
 }
 </style>

--- a/src/components/OperationWizard.vue
+++ b/src/components/OperationWizard.vue
@@ -107,7 +107,7 @@ const calculateColumnSpan = (imageCount) => {
 	return columnsPerImage
 }
 
-const handleClick = (item) => {
+const handleThumbnailClick = (item) => {
 	const index = selectedDSImages.value.findIndex(selectedImage => selectedImage.basename === item.basename)
 	if (index === -1) {
 		selectedDSImages.value.push(item)
@@ -192,7 +192,7 @@ const handleClick = (item) => {
           :class="{ 'selected-image': selectedDSImages.some(selectedImage => selectedImage.basename === image.basename) }"
           cover
           aspect-ratio="1"
-          @click="handleClick(image)"
+          @click="handleThumbnailClick(image)"
         />
       </v-col>
     </v-row>


### PR DESCRIPTION
## FEATURE: Wizard image display and selection

### Description
**Background:**
The Wizard wasn't displaying images before. It's important to display images and be able to select them to know what images we want to manipulate.

**Implementation:**
Started by passing down `images` as props to be able to display all of the images related to a data session in the wizard. Then I added basically the same selection implementation from image carousel here. I also implemented the same function as in the Data Session view to calculate column span. A _**separate**_ story could be globalizing some of these functions/components. 
The next step was to add the selected images as input files to be able to post them. So I did that like this:
```
'input_data': {
	...selectedOperationInput.value,
	'input_files': selectedDataSessionImages.value
}
```
and then I got rid of this line in the `addOperation` function
```
operationDefinition.input_data.input_files = structuredClone(images.value)
```

### Visuals
**Screenshot of the api response in `addOperation` having an image as the `input_files`** 
<img width="1728" alt="Screenshot 2024-02-20 at 3 14 11 PM" src="https://github.com/LCOGT/datalab-ui/assets/54489472/f466898d-581e-4d2b-b431-9bd4d689eec8">

**Video of The Wizard flow**

https://github.com/LCOGT/datalab-ui/assets/54489472/810dbbed-a3fb-4d2a-a3d3-6c59503190bc

