### PR TITLE
Fix/delete datasessions

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -19,14 +19,12 @@ async function fetchApiCall({ url, method, body = null, header, successCallback 
 
 	try {
 		const response = await fetch(url, config)
-
-		// Check for empty or non-JSON response
-		if (response.ok && response.headers.get('Content-Length') === '0') {
-			// No content return a success with null
+		// ok response but empty content
+		if (response.ok && !response.headers.has('content-length'))
+		{
 			successCallback ? successCallback(null) : null
 		} else {
 			const responseData = await response.json()
-
 			if (!response.ok) {
 				console.error('Response not OK', responseData)
 				failCallback ? failCallback(responseData, response.status) : null

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,8 +20,7 @@ async function fetchApiCall({ url, method, body = null, header, successCallback 
 	try {
 		const response = await fetch(url, config)
 		// ok response but empty content
-		if (response.ok && !response.headers.has('content-length'))
-		{
+		if (response.ok && !response.headers.has('content-length')) {
 			successCallback ? successCallback(null) : null
 		} else {
 			const responseData = await response.json()


### PR DESCRIPTION
Fixed a bug where empty header content wasn't being checked properly causing the program to throw an error when it would try to do a response.json(). The delete response from the api is empty but `get('content-length')` was evaluating to undefined which is != 0. Instead we now use the method `has()` so it will check if the response has any content