### PR TITLE
Feature/per proposal

### DIFF
--- a/src/components/Project/ImageCarousel.vue
+++ b/src/components/Project/ImageCarousel.vue
@@ -26,47 +26,6 @@ const handleThumbnailClick = (item, index) => {
 	currLargeImage.value = store.getters.getLargeImageFromBasename(currSmallImage.value.basename)
 }
 
-// SAVING THIS CODE WHEN WE HAVE TO SAVE LAZY LOADED IMAGES IN STORE
-
-// const loadImage = (index) => {
-// 	return index <= currentSlide.value + 6
-// }
-
-// const handleScroll = () => {
-// 	const carousel = document.getElementById('thumbnails')
-// 	if (!carousel) return
-
-// 	const containerWidth = carousel.offsetWidth
-// 	// Calculating thumbnail width, scrolling position, and finding the currentSlide based on the scrollPosition
-// 	const thumbnailWidth = containerWidth * 0.2 - 20 
-// 	const scrollPosition = carousel.scrollLeft
-// 	const visibleThumbnails = Math.floor(scrollPosition / thumbnailWidth)
-
-// 	// Updating the currentSlide reactive variable
-// 	currentSlide.value = visibleThumbnails
-// }
-
-// onMounted(() => {
-// 	const carousel = document.getElementById('thumbnails')
-// 	if (carousel) {
-// 		carousel.addEventListener('scroll', handleScroll, { passive: true })
-// 	}
-// })
-
-// onUnmounted(() => {
-// 	const carousel = document.getElementById('thumbnails')
-// 	if (carousel) {
-// 		carousel.removeEventListener('scroll', handleScroll)
-// 	}
-// })
-
-// watch(currentSlide, (newValue) => {
-// 	for (let i = newValue; i <= newValue + 3 && i < data.value.length; i++) {
-// 		const imageToLoad = data.value[i]
-// 		imageToLoad.loaded = true
-// 	}
-// }, { immediate: true })
-
 </script>
 
 <template>

--- a/src/components/Project/ImageCarousel.vue
+++ b/src/components/Project/ImageCarousel.vue
@@ -1,22 +1,26 @@
 
 <script setup>
-import { ref, defineProps } from 'vue'
+import { ref, defineProps, watch } from 'vue'
 import { useStore } from 'vuex'
 import { Carousel, Slide  } from 'vue3-carousel'
 import 'vue3-carousel/dist/carousel.css'
 import ImageAnalyzer from '../ImageAnalyzer.vue'
 
+const props = defineProps({
+	data: {
+		type: Object,
+		required: true
+	}
+})
+
 const store = useStore()
-const props = defineProps(['data'])
 const currentSlide = ref(0)
-const currSmallImage = ref(props.data[currentSlide.value])
-const currLargeImage = ref(store.getters.getLargeImageFromBasename(currSmallImage.value.basename))
+const currSmallImage = ref(null)
+const currLargeImage = ref(null)
 const showAnalysisDialog = ref(false)
 
-// Invoked any time an image is clicked
 const handleThumbnailClick = (item, index) => {
 	store.dispatch('toggleImageSelection', item)
-	// Checking if there are any selected images after the toggle action
 	if (store.state.selectedImages.length > 0) {
 		currSmallImage.value = store.state.selectedImages[store.state.selectedImages.length - 1]
 		currentSlide.value = props.data.findIndex(img => img.basename === currSmallImage.value.basename)
@@ -25,6 +29,15 @@ const handleThumbnailClick = (item, index) => {
 	}
 	currLargeImage.value = store.getters.getLargeImageFromBasename(currSmallImage.value.basename)
 }
+
+watch(() => props.data, (newVal) => {
+	if (newVal && newVal.length > 0) {
+		currSmallImage.value = newVal[0]
+		currLargeImage.value = store.getters.getLargeImageFromBasename(currSmallImage.value.basename)
+	}
+}, {
+	immediate: true
+})
 
 </script>
 

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -8,7 +8,7 @@ const emit = defineEmits(['update:selectedProject'])
 
 const smallImageCache = computed(() => store.state.smallImageCache)
 
-const groupedItems = computed(() => groupByProposalId(smallImageCache.value))
+const groupedProjects = computed(() => groupByProposalId(smallImageCache.value))
 
 function groupByProposalId(projects) {
 	return projects.reduce((acc, project) => {
@@ -20,7 +20,7 @@ function groupByProposalId(projects) {
 	}, {})
 }
 
-console.log('grouped items:', groupedItems)
+console.log('grouped Projects:', groupedProjects)
 
 const selectProject = (projectTitle) => {
 	emit('update:selectedProject', projectTitle)
@@ -38,7 +38,7 @@ const selectProject = (projectTitle) => {
         class="accordion"
       >
         <ProjectSelector
-          v-for="(project, index) in groupedItems"
+          v-for="(project, index) in groupedProjects"
           :key="index"
           :project="project"
           @click="selectProject(project.projectTitle)"

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -10,12 +10,12 @@ const smallImageCache = computed(() => store.state.smallImageCache)
 
 const groupedItems = computed(() => groupByProposalId(smallImageCache.value))
 
-function groupByProposalId(items) {
-	return items.reduce((acc, item) => {
-		if (!acc[item.proposal_id]) {
-			acc[item.proposal_id] = []
+function groupByProposalId(projects) {
+	return projects.reduce((acc, project) => {
+		if (!acc[project.proposal_id]) {
+			acc[project.proposal_id] = []
 		}
-		acc[item.proposal_id].push(item)
+		acc[project.proposal_id].push(project)
 		return acc
 	}, {})
 }

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -3,7 +3,7 @@ import { defineEmits, defineProps } from 'vue'
 import ProjectSelector from './ProjectSelector.vue'
 
 
-const emit = defineEmits(['update:selectedProject'])
+const emit = defineEmits(['selectedProject'])
 
 defineProps({
 	projects: {
@@ -12,8 +12,9 @@ defineProps({
 	}
 })
 
-const selectProject = (projectTitle) => {
-	emit('update:selectedProject', projectTitle)
+const selectProject = (projects) => {
+	const proposalId = projects.map(p => p.proposal_id)
+	emit('selectedProject', proposalId)
 }
 </script>
 
@@ -31,7 +32,7 @@ const selectProject = (projectTitle) => {
           v-for="(project, index) in projects"
           :key="index"
           :project="project"
-          @click="selectProject(project.projectTitle)"
+          @click="selectProject(project)"
         />
       </v-expansion-panels>
     </v-card>

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -1,26 +1,16 @@
 <script setup>
-import { defineEmits, computed } from 'vue'
-import { useStore } from 'vuex'
+import { defineEmits, defineProps } from 'vue'
 import ProjectSelector from './ProjectSelector.vue'
 
-const store = useStore()
+
 const emit = defineEmits(['update:selectedProject'])
 
-const smallImageCache = computed(() => store.state.smallImageCache)
-
-const groupedProjects = computed(() => groupByProposalId(smallImageCache.value))
-
-function groupByProposalId(projects) {
-	return projects.reduce((acc, project) => {
-		if (!acc[project.proposal_id]) {
-			acc[project.proposal_id] = []
-		}
-		acc[project.proposal_id].push(project)
-		return acc
-	}, {})
-}
-
-console.log('grouped Projects:', groupedProjects)
+defineProps({
+	projects: {
+		type: Object,
+		required: true
+	}
+})
 
 const selectProject = (projectTitle) => {
 	emit('update:selectedProject', projectTitle)
@@ -38,7 +28,7 @@ const selectProject = (projectTitle) => {
         class="accordion"
       >
         <ProjectSelector
-          v-for="(project, index) in groupedProjects"
+          v-for="(project, index) in projects"
           :key="index"
           :project="project"
           @click="selectProject(project.projectTitle)"

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -1,17 +1,26 @@
 <script setup>
-import { ref, defineEmits } from 'vue'
+import { defineEmits, computed } from 'vue'
+import { useStore } from 'vuex'
 import ProjectSelector from './ProjectSelector.vue'
 
-const projects = ref([
-	{ projectTitle: 'PROJECT 1', projectDescription: 'things like site code, date, image id, etc can go in here'},
-	{ projectTitle: 'PROJECT 2', projectDescription: 'things like site code, date, image id, etc can go in here'},
-	{ projectTitle: 'PROJECT 3', projectDescription: 'things like site code, date, image id, etc can go in here'},
-	{ projectTitle: 'PROJECT 4', projectDescription: 'things like site code, date, image id, etc can go in here'},
-	{ projectTitle: 'PROJECT 5', projectDescription: 'things like site code, date, image id, etc can go in here'},
-])
-
-
+const store = useStore()
 const emit = defineEmits(['update:selectedProject'])
+
+const smallImageCache = computed(() => store.state.smallImageCache)
+
+const groupedItems = computed(() => groupByProposalId(smallImageCache.value))
+
+function groupByProposalId(items) {
+	return items.reduce((acc, item) => {
+		if (!acc[item.proposal_id]) {
+			acc[item.proposal_id] = []
+		}
+		acc[item.proposal_id].push(item)
+		return acc
+	}, {})
+}
+
+console.log('grouped items:', groupedItems)
 
 const selectProject = (projectTitle) => {
 	emit('update:selectedProject', projectTitle)
@@ -29,7 +38,7 @@ const selectProject = (projectTitle) => {
         class="accordion"
       >
         <ProjectSelector
-          v-for="(project, index) in projects"
+          v-for="(project, index) in groupedItems"
           :key="index"
           :project="project"
           @click="selectProject(project.projectTitle)"

--- a/src/components/Project/ProjectSelector.vue
+++ b/src/components/Project/ProjectSelector.vue
@@ -1,8 +1,12 @@
-<!-- eslint-disable vue/require-prop-types -->
 <script setup>
 import { defineProps } from 'vue'
-defineProps(['project'])
-
+const props = defineProps({
+	project: {
+		type: Object,
+		required: true
+	}
+})
+console.log('props:', props.project)
 </script>
 
 <template>
@@ -11,11 +15,8 @@ defineProps(['project'])
       expand-icon="mdi-menu-down"
       class="projects_title"
     >
-      {{ project.projectTitle }}
+      {{ project[0].proposal_id }}
     </v-expansion-panel-title>
-    <v-expansion-panel-text class="project_description">
-      {{ project.projectDescription }}
-    </v-expansion-panel-text>
   </v-expansion-panel>
 </template>
 

--- a/src/components/Project/ProjectSelector.vue
+++ b/src/components/Project/ProjectSelector.vue
@@ -12,11 +12,16 @@ console.log('props:', props.project)
 <template>
   <v-expansion-panel>
     <v-expansion-panel-title
-      expand-icon="mdi-menu-down"
+      icon="chevron-down"
       class="projects_title"
     >
       {{ project[0].proposal_id }}
     </v-expansion-panel-title>
+    <v-expansion-panel-text>
+      <p class="project_description">
+        Project ID: {{ project[0].id }}
+      </p>
+    </v-expansion-panel-text>
   </v-expansion-panel>
 </template>
 
@@ -29,9 +34,10 @@ console.log('props:', props.project)
   background-color: var(--metal);
 }
 .project_description {
-  font-size: 1.2rem;
+  font-size: 1.3rem;
+  font-weight: 500;
   text-align: left;
-  color: var(--light-gray);
+  color: var(--tan);
 }
 
 @media (max-width: 1200px) {

--- a/src/components/Project/ProjectSelector.vue
+++ b/src/components/Project/ProjectSelector.vue
@@ -3,7 +3,7 @@ import { defineProps } from 'vue'
 
 defineProps({
 	project: {
-		type: Object,
+		type: Array,
 		required: true
 	}
 })

--- a/src/components/Project/ProjectSelector.vue
+++ b/src/components/Project/ProjectSelector.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { defineProps } from 'vue'
-const props = defineProps({
+
+defineProps({
 	project: {
 		type: Object,
 		required: true
 	}
 })
-console.log('props:', props.project)
+
 </script>
 
 <template>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -55,12 +55,12 @@ function updateGroupedProjects() {
 	const firstProjectKey = Object.keys(projects.value)[0]
 	if (firstProjectKey) {
 		const firstProjectProposalIds = [firstProjectKey]
-		handleSelectedProject(firstProjectProposalIds)
+		filterImagesByProposalId(firstProjectProposalIds)
 	}
 }
 
 // handles the selected project to filter images that only have the selected proposal_id
-const handleSelectedProject = (proposalId) => {
+const filterImagesByProposalId = (proposalId) => {
 	selectedProjectImages.value = smallImageCache.value.filter(image => proposalId.includes(image.proposal_id))
 }
 
@@ -168,7 +168,7 @@ onMounted(() => {
     <ProjectBar
       class="project-bar"
       :projects="projects"
-      @selected-project="handleSelectedProject"
+      @selected-project="filterImagesByProposalId"
     />
     <div class="image-area h-screen">
       <div

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -25,6 +25,7 @@ let imageDisplayToggle = ref(true)
 
 let smallImageCache = ref([])
 const projects = ref({})
+const selectedProjectImages = ref([])
 
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async (option) => {
@@ -35,6 +36,7 @@ const loadUserImages = async (option) => {
 	updateGroupedProjects()
 }
 
+// groups all projects by proposal id
 function groupByProposalId() {
 	if (smallImageCache.value) {
 		return smallImageCache.value.reduce((acc, project) => {
@@ -47,8 +49,19 @@ function groupByProposalId() {
 	}
 }
 
+// 
 function updateGroupedProjects() {
 	projects.value = groupByProposalId(smallImageCache.value)
+	const firstProjectKey = Object.keys(projects.value)[0] // Get the first key of the projects object
+	if (firstProjectKey) {
+		const firstProjectProposalIds = [firstProjectKey] // Since handleSelectedProject expects an array of proposalIds
+		handleSelectedProject(firstProjectProposalIds)
+	}
+
+}
+
+const handleSelectedProject = (proposalId) => {
+	selectedProjectImages.value = smallImageCache.value.filter(image => proposalId.includes(image.proposal_id))
 }
 
 // boolean computed property used to disable the add to session button
@@ -148,12 +161,14 @@ onMounted(() => {
 })
 
 </script>
+
 <template>
   <!-- only load if config is loaded -->
   <div class="container">
     <ProjectBar
       class="project-bar"
       :projects="projects"
+      @selected-project="handleSelectedProject"
     />
     <div class="image-area h-screen">
       <div
@@ -170,12 +185,12 @@ onMounted(() => {
 
       <div v-else>
         <ImageCarousel
-          v-if="imageDisplayToggle && store.state.smallImageCache.length && store.state.largeImageCache.length"
-          :data="store.state.smallImageCache"
+          v-if="imageDisplayToggle && selectedProjectImages.length"
+          :data="selectedProjectImages"
         />
         <ImageList
-          v-if="!imageDisplayToggle && store.state.smallImageCache.length && store.state.largeImageCache.length"
-          :data="store.state.smallImageCache"
+          v-if="!imageDisplayToggle && selectedProjectImages.length"
+          :data="selectedProjectImages"
         />
       </div>
       <v-skeleton-loader

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -192,6 +192,9 @@ onMounted(() => {
           v-if="!imageDisplayToggle && selectedProjectImages.length"
           :data="selectedProjectImages"
         />
+        <p v-if="!selectedProjectImages.length">
+          Please create a project to use Datalab
+        </p>
       </div>
       <v-skeleton-loader
         v-if="!store.state.smallImageCache"

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -23,11 +23,32 @@ onBeforeMount(()=>{
 // toggle for optional data viewing, controlled by a v-switch
 let imageDisplayToggle = ref(true)
 
+let smallImageCache = ref([])
+const projects = ref({})
+
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async (option) => {
 	isLoading.value = true
 	await store.dispatch('loadAndCacheImages', { option })
 	isLoading.value = false
+	smallImageCache.value = store.state.smallImageCache
+	updateGroupedProjects()
+}
+
+function groupByProposalId() {
+	if (smallImageCache.value) {
+		return smallImageCache.value.reduce((acc, project) => {
+			if (!acc[project.proposal_id]) {
+				acc[project.proposal_id] = []
+			}
+			acc[project.proposal_id].push(project)
+			return acc
+		}, {})
+	}
+}
+
+function updateGroupedProjects() {
+	projects.value = groupByProposalId(smallImageCache.value)
 }
 
 // boolean computed property used to disable the add to session button
@@ -130,7 +151,10 @@ onMounted(() => {
 <template>
   <!-- only load if config is loaded -->
   <div class="container">
-    <ProjectBar class="project-bar" />
+    <ProjectBar
+      class="project-bar"
+      :projects="projects"
+    />
     <div class="image-area h-screen">
       <div
         v-if="isLoading"

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -49,17 +49,17 @@ function groupByProposalId() {
 	}
 }
 
-// 
+// sorts projects by group id and handles selectedproject as the first one for when the page first loads 
 function updateGroupedProjects() {
 	projects.value = groupByProposalId(smallImageCache.value)
-	const firstProjectKey = Object.keys(projects.value)[0] // Get the first key of the projects object
+	const firstProjectKey = Object.keys(projects.value)[0]
 	if (firstProjectKey) {
-		const firstProjectProposalIds = [firstProjectKey] // Since handleSelectedProject expects an array of proposalIds
+		const firstProjectProposalIds = [firstProjectKey]
 		handleSelectedProject(firstProjectProposalIds)
 	}
-
 }
 
+// handles the selected project to filter images that only have the selected proposal_id
 const handleSelectedProject = (proposalId) => {
 	selectedProjectImages.value = smallImageCache.value.filter(image => proposalId.includes(image.proposal_id))
 }


### PR DESCRIPTION
## FEATURE: Display data associated to the proposal

**Background:**
We had a static project bar where it would just have static titles and the images wouldn't change based on the selected project. This has now changed to accurately display the data associated with each proposal_id

**Implementation**
Are you even gonna read this Jon? Please read this. Anyway:
`Project View`: added logic to sort projects by proposal id as well as handling the selection of a project to display the correct images 
`Project Bar`: defined props to be able to properly select a project 
`Project Selector`: defined props to be show proposal_id and project_id as "description". This is temporary and we can talk about what we actually want to show. 
`Image Carousel`: initialized currSmallImage and CurrLargeImage as null so that we can display the first ones when page loads. Additionally, added a watcher that looks for changes in props.data which happens when a different project is selected. 

### VISUALS

**Screen recording of new changes**


https://github.com/LCOGT/datalab-ui/assets/54489472/61c2f2f5-184a-4e6c-b547-086c608329a2

