### PR TITLE
separated switch text into a div

### DIFF
--- a/src/components/ColorblindToggle.vue
+++ b/src/components/ColorblindToggle.vue
@@ -6,20 +6,24 @@ const store = useStore()
 
 const isColorblindMode = ref(false)
 
-function toggleColorblindMode() {
+const toggleColorblindMode = () => {
+	isColorblindMode.value = !isColorblindMode.value
 	store.dispatch('toggleColorblindMode')
 }
-
 </script>
 
 <template>
   <div class="colorblind-toggle-container">
     <v-switch
       v-model="isColorblindMode"
-      :label="`Colorblind Mode: ${isColorblindMode ? 'On' : 'Off'}`"
       class="colorblind-toggle"
-      @click="toggleColorblindMode"
+      inset
+      opacity="100"
+      @click.stop="toggleColorblindMode"
     />
+    <div class="label">
+      Colorblind Mode: {{ isColorblindMode ? 'On' : 'Off' }}
+    </div>
   </div>
 </template>
 
@@ -30,10 +34,17 @@ function toggleColorblindMode() {
   top: -0.5rem;
   z-index: 2000;
   margin-right: 0.3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .colorblind-toggle {
-  color: white;
   font-weight: 600;
   padding: 0.6rem;
+}
+.label {
+  margin-right: 1rem;
+  margin-bottom: 8%;
+  cursor: default;
 }
 </style>


### PR DESCRIPTION
## FIX: clicking of button rather than text

Quick fix, added a div to the text and now the toggle only toggles when user clicks the switch rather than the text. Didn't change any logic