### PR TITLE
Chore/display proper data

### DIFF
--- a/src/components/Project/ImageCarousel.vue
+++ b/src/components/Project/ImageCarousel.vue
@@ -8,10 +8,14 @@ import ImageAnalyzer from '../ImageAnalyzer.vue'
 
 const props = defineProps({
 	data: {
-		type: Object,
+		type: Array,
 		required: true
 	}
 })
+
+// const test = () => {
+// 	(props.data.map((data) => store.state.selectedImages[length-1]==(data) ? console.log('yes') : console.log('no')))
+// }
 
 const store = useStore()
 const currentSlide = ref(0)
@@ -20,9 +24,12 @@ const currLargeImage = ref(null)
 const showAnalysisDialog = ref(false)
 
 const handleThumbnailClick = (item, index) => {
+	// test()
 	store.dispatch('toggleImageSelection', item)
-	if (store.state.selectedImages.length > 0) {
-		currSmallImage.value = store.state.selectedImages[store.state.selectedImages.length - 1]
+	const lastSelectedImage = store.state.selectedImages.length > 0 ? store.state.selectedImages[store.state.selectedImages.length - 1] : null
+	const isLastSelectedImageInCurrentProject = lastSelectedImage && props.data.some(img => img.basename === lastSelectedImage.basename)
+	if (isLastSelectedImageInCurrentProject) {
+		currSmallImage.value = lastSelectedImage
 		currentSlide.value = props.data.findIndex(img => img.basename === currSmallImage.value.basename)
 	} else {
 		currentSlide.value = index
@@ -31,6 +38,8 @@ const handleThumbnailClick = (item, index) => {
 }
 
 watch(() => props.data, (newVal) => {
+
+	console.log('propsdata:', props.data)
 	if (newVal && newVal.length > 0) {
 		currSmallImage.value = newVal[0]
 		currLargeImage.value = store.getters.getLargeImageFromBasename(currSmallImage.value.basename)

--- a/src/components/Project/ImageCarousel.vue
+++ b/src/components/Project/ImageCarousel.vue
@@ -13,10 +13,6 @@ const props = defineProps({
 	}
 })
 
-// const test = () => {
-// 	(props.data.map((data) => store.state.selectedImages[length-1]==(data) ? console.log('yes') : console.log('no')))
-// }
-
 const store = useStore()
 const currentSlide = ref(0)
 const currSmallImage = ref(null)
@@ -24,7 +20,6 @@ const currLargeImage = ref(null)
 const showAnalysisDialog = ref(false)
 
 const handleThumbnailClick = (item, index) => {
-	// test()
 	store.dispatch('toggleImageSelection', item)
 	const lastSelectedImage = store.state.selectedImages.length > 0 ? store.state.selectedImages[store.state.selectedImages.length - 1] : null
 	const isLastSelectedImageInCurrentProject = lastSelectedImage && props.data.some(img => img.basename === lastSelectedImage.basename)
@@ -38,8 +33,6 @@ const handleThumbnailClick = (item, index) => {
 }
 
 watch(() => props.data, (newVal) => {
-
-	console.log('propsdata:', props.data)
 	if (newVal && newVal.length > 0) {
 		currSmallImage.value = newVal[0]
 		currLargeImage.value = store.getters.getLargeImageFromBasename(currSmallImage.value.basename)


### PR DESCRIPTION
## CHORE: Display the correct large image when user unselects images

**Background:**
If user navigated to Project X and selected 2 images, then navigated to Project Y and selected 1 image and then unselected it, the large image displayed would be the last one selected from Project X. This is now fixed

**Implementation:**
In `handleThumbnailClick`, I added a couple of checks. 
First, `lastSelectedImages` checks if the `selectedImages` from store has length. If so, then we return the last one added to the array. Otherwise, we return null.
Then, `isLastSelectedImageInCurrentProject` has an existence check for `lastSelectedImage` (`&&` is an existence check in JS). And then it checks if some image in `props.data` has a basename that's equal to that of `lastSelectedImage`. 
If all of this is true, then we proceed as usual. Else, we set the `currentSlide` value to be that of index. 

The end

### Visuals
**Screen recording of the navigation of this process with the correct images displayed**


https://github.com/LCOGT/datalab-ui/assets/54489472/41bcc1fa-8f8c-44d7-aba6-6db49a93126f



