### PR TITLE
polling for operation completion

### DIFF
--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -47,14 +47,16 @@ function operationBtnColor(index) {
 async function pollOperationCompletion(operationID) {
 	const url = await store.state.datalabApiBaseUrl + 'datasessions/' + props.data.id + '/operations/' + operationID + '/'
 
-	const response = await fetchApiCall({ url: url, method: 'GET', failCallback: handleError })
-
-	if (response && response.percent_completion !== undefined && response.status != 'COMPLETED') {
-		operationPercentages.value[operationID] = response.percent_completion * DEC_TO_PERCENT
-	} else {
-		operationPercentages.value[operationID] = COMPLETE_PERCENT
-		setTimeout(stopPollingOperation(operationID), POLL_WAIT_TIME)
+	const updateOperationPercentages = (response) => {
+		if (response && response.percent_completion !== undefined && response.status != 'COMPLETED') {
+			operationPercentages.value[operationID] = response.percent_completion * DEC_TO_PERCENT
+		} else {
+			operationPercentages.value[operationID] = COMPLETE_PERCENT
+			setTimeout(stopPollingOperation(operationID), POLL_WAIT_TIME)
+		}
 	}
+
+	await fetchApiCall({ url: url, method: 'GET', successCallback: updateOperationPercentages, failCallback: handleError })
 }
 
 function stopPollingOperation(operationID) {


### PR DESCRIPTION
Adds a watcher on props.operation to add polling intervals to each. Polls operations for completion and represents it visually with a loading bar under the button. Cleans up intervals after polling completes. Scoping this story down to just the polling logic, improvements on how it is visualized will be on a different PR.

Loading bar appears like in the top image and then is cleared when the object finished loading
![Screenshot 2024-03-01 at 11 01 53 AM](https://github.com/LCOGT/datalab-ui/assets/54085254/973430f4-7b4a-45aa-9ffa-15ed19174695)
This image is to highlight the polling process
![Screenshot 2024-03-01 at 10 53 31 AM](https://github.com/LCOGT/datalab-ui/assets/54085254/914b2aff-e928-4ca5-b17a-184e69a02b5b)
