### PR TITLE
Fix: Wizard styling buttons

### DIFF
--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -275,9 +275,8 @@ const handleThumbnailClick = (item) => {
 }
 .operation-input {
   width: 10vw;
-  position: fixed;
   left: 3%;
-  top: 7%;
+  margin-bottom: 2%;
   background-color: var(--metal);
 }
 .buttons-container {
@@ -295,11 +294,10 @@ const handleThumbnailClick = (item) => {
 }
 @media (max-width: 1200px) {
 .operation-input {
-  left: 5%;
-  top: 10%;
+  margin-left: 3%;
 }
 .images-container {
-  margin-top: 8%;
+  margin-top: 2%;
 }
 }
 @media (max-width: 900px) {
@@ -310,12 +308,11 @@ const handleThumbnailClick = (item) => {
   font-size: 1rem;
 }
 .operation-input {
-  left: 5%;
-  top: 7%;
+  margin-left: 4%;
   width: 15vw;
 }
 .images-container {
-  margin-top: 15%;
+  margin-top: 3%;
 }
 }
 </style>

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -20,7 +20,7 @@ const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedDataSessionImages = ref([])
-const imagesPerRow = 4
+const imagesPerRow = 5
 
 let displayImages = ref(false)
 

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -20,7 +20,7 @@ const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedDataSessionImages = ref([])
-const imagesPerRow = 5
+const imagesPerRow = 4
 
 let displayImages = ref(false)
 
@@ -192,7 +192,7 @@ const handleThumbnailClick = (item) => {
       </v-card-text>
     </v-slide-y-reverse-transition>
 
-    <v-card-actions>
+    <v-card-actions class="buttons-container">
       <v-spacer />
       <v-btn
         variant="text"
@@ -215,6 +215,7 @@ const handleThumbnailClick = (item) => {
 <style scoped>
 .wizard-background{
   background-color: var(--dark-blue);
+  height: 100vh;
 }
 .wizard-toolbar {
   background-color: var(--metal);
@@ -259,7 +260,6 @@ const handleThumbnailClick = (item) => {
   flex-wrap: wrap; 
   justify-content: flex-start; 
   width: 100%; 
-  margin-bottom: 50vw; 
   padding-left: 2rem; 
   padding-right: 2rem; 
 }
@@ -275,6 +275,11 @@ const handleThumbnailClick = (item) => {
 .operation-input {
   width: 10vw;
   margin-bottom: 1rem;
+}
+.buttons-container {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
 }
 .goback-btn {
   color: var(--cancel);

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -275,7 +275,7 @@ const handleThumbnailClick = (item) => {
 }
 .operation-input {
   width: 10vw;
-  left: 3%;
+  margin-left: 2%;
   margin-bottom: 2%;
   background-color: var(--metal);
 }

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -20,7 +20,7 @@ const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedDataSessionImages = ref([])
-const imagesPerRow = 5
+const imagesPerRow = 3
 
 let displayImages = ref(false)
 
@@ -168,6 +168,7 @@ const handleThumbnailClick = (item) => {
         <div
           v-for="(inputDescription, inputKey) in selectedOperationInputs"
           :key="inputKey"
+          class="operation-input-wrapper"
         >
           <v-text-field
             v-if="inputDescription.type !== 'file'"
@@ -274,7 +275,10 @@ const handleThumbnailClick = (item) => {
 }
 .operation-input {
   width: 10vw;
-  margin-bottom: 1rem;
+  position: fixed;
+  left: 3%;
+  top: 7%;
+  background-color: var(--metal);
 }
 .buttons-container {
   position: fixed;
@@ -289,12 +293,29 @@ const handleThumbnailClick = (item) => {
   color:var(--light-blue);
   font-size: 1.2rem;
 }
+@media (max-width: 1200px) {
+.operation-input {
+  left: 5%;
+  top: 10%;
+}
+.images-container {
+  margin-top: 8%;
+}
+}
 @media (max-width: 900px) {
 .selected-operation {
   height: 120%;
 }
 .operation-description{
   font-size: 1rem;
+}
+.operation-input {
+  left: 5%;
+  top: 7%;
+  width: 15vw;
+}
+.images-container {
+  margin-top: 15%;
 }
 }
 </style>


### PR DESCRIPTION
### QUICK FIX: Wizard buttons position

Set the wizard buttons to have a position of fixed. For the screen recording, I changed `imagesPerRow` to be able to show that the buttons have a fixed position

**UPDATED AFTER LLOYD'S FEEDBACK**

https://github.com/LCOGT/datalab-ui/assets/54489472/555488b5-f4f8-4c1b-8228-ab1b01875aa2



Tablet views



https://github.com/LCOGT/datalab-ui/assets/54489472/385218fb-f63a-40c1-b63e-1286e332c78a


https://github.com/LCOGT/datalab-ui/assets/54489472/61cb59ba-b9e0-443b-92ea-e69e04d4dcc7


