### PR TITLE
Fix/reroute session postdeletion

### DIFF
--- a/src/components/DataSession/DeleteSessionDialog.vue
+++ b/src/components/DataSession/DeleteSessionDialog.vue
@@ -14,12 +14,16 @@ const dataSessionsUrl = datalabApiBaseUrl + 'datasessions/'
 
 function closeDialog() { 
 	emit('update:modelValue', false)
+}
+
+function sessionDeleted(){
 	emit('reloadSession')
+	closeDialog()
 }
 
 async function confirmDeleteSession() {
 	const url = dataSessionsUrl + props.deleteId
-	await fetchApiCall({url: url, method: 'DELETE', successCallback: closeDialog, failCallback: () => {showSnackBar.value=true} })
+	await fetchApiCall({url: url, method: 'DELETE', successCallback: sessionDeleted, failCallback: () => {showSnackBar.value=true} })
 }
 </script>
 <template>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -14,7 +14,6 @@ const tab = ref()
 const deleteSessionId = ref(-1)
 const showDeleteDialog = ref(false)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
-const selectedTab = ref(-1)
 
 onBeforeMount(()=>{
 	if(!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
@@ -34,7 +33,7 @@ onMounted(async () => {
 		} else {
 			console.log('no data sessions available to display')
 		}
-		
+
 	}
 })
 
@@ -42,22 +41,13 @@ function onTabChange(newSessionId) {
 	router.push({ name: 'DataSessionDetails', params: { sessionId: newSessionId }})
 }
 
-async function deleteSession(id) {
+function deleteSession(id) {
 	deleteSessionId.value = id
 	showDeleteDialog.value = true
 }
 
 async function loadSessions() {
 	await fetchApiCall({url: dataSessionsUrl, method: 'GET', successCallback: (data) => {dataSessions.value = data.results}, failCallback: handleError})
-}
-
-function selectTab(index) {
-	if (index == selectedTab.value) {
-		selectedTab.value = -1
-	}
-	else {
-		selectedTab.value = index
-	}
 }
 
 function tabColor(index) {
@@ -87,7 +77,6 @@ function tabColor(index) {
           :value="ds.id"
           :class="tabColor(index)"
           class="pr-0 tab"
-          @click="selectTab(index)"
         >
           {{ ds.name }}
           <v-btn

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -35,25 +35,25 @@ onMounted(async () => {
 	}
 })
 
-function changeTab(newSessionId) {
+function onTabChange(newSessionId) {
 	tab.value = newSessionId
 }
 
-function deleteDialog(id) {
+function openDeleteDialog(id) {
 	deleteSessionId.value = id
 	showDeleteDialog.value = true
 }
 
 async function loadSessions() {
-	// if tab is not in new data default to displaying first tab
-	function updateData(data) {
-		dataSessions.value = data.results
-		if(!dataSessions.value.some(ds => ds.id == tab.value)){
-			tab.value = dataSessions.value[0]?.id
-		}
-	}
-
 	await fetchApiCall({url: dataSessionsUrl, method: 'GET', successCallback: updateData, failCallback: handleError})
+}
+
+// if tab is not in new data default to displaying first tab
+function updateData(data) {
+	dataSessions.value = data.results
+	if(!dataSessions.value.some(ds => ds.id == tab.value)){
+		tab.value = dataSessions.value[0]?.id
+	}
 }
 
 function tabColor(index) {
@@ -75,7 +75,7 @@ function tabColor(index) {
         next-icon="mdi-arrow-right-bold-box-outline"
         prev-icon="mdi-arrow-left-bold-box-outline"
         show-arrows
-        @update:model-value="changeTab"
+        @update:model-value="onTabChange"
       >
         <v-tab
           v-for="(ds, index) in dataSessions"
@@ -90,7 +90,7 @@ function tabColor(index) {
             icon="mdi-close"
             class="tab_button"
             :class="tabColor(index)"
-            @click="deleteDialog(ds.id)"
+            @click="openDeleteDialog(ds.id)"
           />
         </v-tab>
         <v-btn


### PR DESCRIPTION
Deleting sessions will now send you to the first tab instead of just greeting you with a blank screen.

So a few changes
- added a check to loadSessions that helps when sessions are deleted. it checks whether our current tab is in the new data. if not then it sets tab to the first datasession
- just changed the v-model of v-tabs instead of using the router and onMounted to do so ( still can load a project from a url param, just doesn't reload the page when we change tabs ) 
- Selected tabs was not being used at all, guessing somewhere it got overwritten/replaced but wasn't removed
- line 26 is a bug I caught where you could put a param into the url of a data session that doesn't exist and then nothing would show up ( the later part of the video where you can't see my browser but I put in /999 and it handles it instead of being blank like before )



https://github.com/LCOGT/datalab-ui/assets/54085254/6126e5ef-87fc-44c3-a133-53b092009e8f

