### PR TITLE
Styling/images per row

### DIFF
--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -31,7 +31,6 @@ const updateImagesPerRow = () => {
 	} else {
 		imagesPerRow.value = 3
 	}
-	console.log('Images per row:', imagesPerRow.value)
 }
 
 let displayImages = ref(false)

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed, defineEmits, defineProps } from 'vue'
+import { ref, onMounted, onUnmounted, computed, defineEmits, defineProps} from 'vue'
 import { fetchApiCall, handleError } from '../../utils/api'
 import { calculateColumnSpan } from '../../utils/common'
 import ImageGrid from '../Global/ImageGrid'
@@ -20,7 +20,19 @@ const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedDataSessionImages = ref([])
-const imagesPerRow = 3
+const imagesPerRow = ref(3)
+
+const updateImagesPerRow = () => {
+	const width = window.innerWidth
+	if (width >= 1200) {
+		imagesPerRow.value = 5
+	} else if (width >= 900) {
+		imagesPerRow.value = 4
+	} else {
+		imagesPerRow.value = 3
+	}
+	console.log('Images per row:', imagesPerRow.value)
+}
 
 let displayImages = ref(false)
 
@@ -30,6 +42,12 @@ onMounted(async () => {
 	if (Object.keys(availableOperations.value).length > 0){
 		selectOperation(Object.keys(availableOperations.value)[0])
 	}
+	updateImagesPerRow()
+	window.addEventListener('resize', updateImagesPerRow)
+})
+
+onUnmounted(() => {
+	window.removeEventListener('resize', updateImagesPerRow)
 })
 
 const page = ref('select')


### PR DESCRIPTION
## STYLING: Updating the number of images per row based on screen size 

The title says it all. I added logic to check for the size of the window as well as an event listener and change the value of `imagesPerRow` based on that. The screen recording shows a big margin on top but that only comes up when the user has console open. I can write a separate story for that. 


https://github.com/LCOGT/datalab-ui/assets/54489472/190cc2c3-1e2e-4d31-97f6-f523848edda9

