### PR TITLE
wrapped reload session emit in a function

### DIFF
--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -26,7 +26,13 @@ async function addOperation(operationDefinition) {
 			image.source = 'archive'
 		}
 	}
-	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: emit('reloadSession'), failCallback: handleError})
+
+	// first operation doesn't load unless this is here
+	function postOperationSuccess(){
+		emit('reloadSession')
+	}
+	
+	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: postOperationSuccess, failCallback: handleError})
 }
 
 </script>


### PR DESCRIPTION
Before the first operation added to a data session would not show up.
This fixes the problem but don't know why.
Please merge.