### PR TITLE
Chore/fix colorblind toggle

### DIFF
--- a/src/components/ColorblindToggle.vue
+++ b/src/components/ColorblindToggle.vue
@@ -18,6 +18,7 @@ const toggleColorblindMode = () => {
       v-model="isColorblindMode"
       class="colorblind-toggle"
       opacity="100"
+      d-inline-block
       @click.stop="toggleColorblindMode"
     />
     <div class="label">
@@ -35,14 +36,15 @@ const toggleColorblindMode = () => {
   display: flex;
   align-items: center;
   justify-content: center;
+  max-width: 17%;
 }
 .colorblind-toggle {
-  font-weight: 600;
-  padding: 0.6rem;
+  font-weight: 800;
+  padding: 0.2rem;
 }
 .label {
-  margin-right: 1rem;
-  margin-bottom: 8%;
+  margin-bottom: 12%;
   cursor: default;
+  font-size: 0.82rem;
 }
 </style>

--- a/src/components/ColorblindToggle.vue
+++ b/src/components/ColorblindToggle.vue
@@ -17,23 +17,21 @@ const toggleColorblindMode = () => {
     <v-switch
       v-model="isColorblindMode"
       class="colorblind-toggle"
-      inset
       opacity="100"
       @click.stop="toggleColorblindMode"
     />
     <div class="label">
-      Colorblind Mode: {{ isColorblindMode ? 'On' : 'Off' }}
+      COLORBLIND MODE: {{ isColorblindMode ? 'ON' : 'OFF' }}
     </div>
   </div>
 </template>
 
 <style scoped>
 .colorblind-toggle-container {
-  position: absolute;
-  right: 0.7rem;
-  top: -0.5rem;
+  position: fixed;
+  right: 1%;
+  top: 0.25%;
   z-index: 2000;
-  margin-right: 0.3rem;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ColorblindToggle.vue
+++ b/src/components/ColorblindToggle.vue
@@ -47,4 +47,16 @@ const toggleColorblindMode = () => {
   cursor: default;
   font-size: 0.82rem;
 }
+@media (max-width: 900px) {
+.colorblind-toggle {
+  display: flex;
+  flex-direction: row-reverse;
+  right: 0.25%;
+  top: 0.5%;
+}
+.label {
+  margin-top: 12%;
+  font-size: 0.7rem;
+}
+}
 </style>

--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -174,11 +174,12 @@ onBeforeUnmount(() => {
 }
 @media (max-width: 900px) {
   .operations {
-    font-size: 1.2rem;
+    font-size: 1rem;
   }
   .addop_button {
-    font-size: 0.9rem;
+    font-size: 0.8rem;
     height: 4vh;
+    width: 24vw;
   }
   .operation_button {
     width: 15vw;

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -122,11 +122,6 @@ function tabColor(index) {
 </template>
 
 <style scoped>
-.datasession-container {
-  position: fixed;
-  left: 2%;
-  width: 80vw;
-}
 .tabs {
   background-color: var(--metal);
   border-bottom: 0.1rem solid var(--tan);

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -162,4 +162,9 @@ function tabColor(index) {
     margin: 0;
   }
 }
+@media (max-width: 900px) {
+  .datasession-container {
+    width: 80vw;
+  }
+}
 </style>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -67,7 +67,7 @@ function tabColor(index) {
 </script>
 
 <template>
-  <v-container class="d-lg">
+  <v-container class="d-lg datasession-container">
     <v-card>
       <v-tabs 
         v-model="tab"
@@ -122,6 +122,11 @@ function tabColor(index) {
 </template>
 
 <style scoped>
+.datasession-container {
+  position: fixed;
+  left: 2%;
+  width: 80vw;
+}
 .tabs {
   background-color: var(--metal);
   border-bottom: 0.1rem solid var(--tan);
@@ -146,6 +151,10 @@ function tabColor(index) {
   background-color: var(--metal);
 }
 @media (max-width: 1200px) {
+.datasession-container {
+  width: 85vw;
+  justify-content: left;
+}
   .tab {
     font-size: 0.85rem;
   }

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -268,17 +268,17 @@ onMounted(() => {
   </v-dialog>
 </template>
 <style scoped>
-.card{
-  height: 450px;
-  width: 700px;
-  align-self: center;
-}
 .container{
   margin: 0;
   display: grid;
   grid-template-columns: [col1-start] 1fr [col1-end col2-start] 80% [col2-end];
   grid-template-rows: [row-start] 100% [row-end];
   height: 100vh;
+}
+.card{
+  height: 450px;
+  width: 700px;
+  align-self: center;
 }
 .sessions_header {
   font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
## CHORE: FIX COLORBLIND TOGGLE
**Background:**
There was some overlap with the color blind toggle and a couple of views. While this is still not perfect, it's presentable for tomorrow. Only made css changes
<img width="1715" alt="Screenshot 2024-03-04 at 12 45 34 PM" src="https://github.com/LCOGT/datalab-ui/assets/54489472/a3f57790-4620-4fcc-934a-e3c29f222fdb">

![0A5D946C-CC96-4E28-963A-5E0F4EBE197E](https://github.com/LCOGT/datalab-ui/assets/54489472/8a40ce8c-6802-4806-9f1a-f6c0c27a850a)

![9245026B-32B8-4E91-BDBD-F5D6B0C3F52E](https://github.com/LCOGT/datalab-ui/assets/54489472/a3ba26f8-d918-4e71-8669-8b1eb0e5306f)
