### PR TITLE
Updated the ImageGrid and DataSession View to show output images

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,29 +8,29 @@ const loadedConfig = computed(() => store.state.isConfigLoaded)
 
 // loading config  when app first mounts
 onMounted(async () => {
-	try {
-		const response = await fetch('/config/config.json')
-		if (!response.ok) {
-			throw Error('Failed to load configuration')
-		}
-		const config = await response.json()
-		if (config) {
-			store.commit('setIsConfigLoaded', true)
-			store.commit('setDatalabApiBaseUrl', config.datalabApiBaseUrl)
-			store.commit('setObservationPortalUrl', config.observationPortalUrl)
-			store.commit('setDatalabArchiveUrl', config.dataLabArchiveApiUrl)
-		}  
-	} catch (error) {
-		console.error('Error loading configuration:', error)
-	} 
+  try {
+    const response = await fetch('/config/config.json')
+    if (!response.ok) {
+      throw Error('Failed to load configuration')
+    }
+    const config = await response.json()
+    if (config) {
+      store.commit('setIsConfigLoaded', true)
+      store.commit('setDatalabApiBaseUrl', config.datalabApiBaseUrl)
+      store.commit('setObservationPortalUrl', config.observationPortalUrl)
+      store.commit('setDatalabArchiveUrl', config.dataLabArchiveApiUrl)
+    }
+  } catch (error) {
+    console.error('Error loading configuration:', error)
+  }
 })
 
 watch(() => store.state.isColorblindMode, (newVal) => {
-	if (newVal) {
-		document.documentElement.setAttribute('colorblind', 'true')
-	} else {
-		document.documentElement.removeAttribute('colorblind')
-	}
+  if (newVal) {
+    document.documentElement.setAttribute('colorblind', 'true')
+  } else {
+    document.documentElement.removeAttribute('colorblind')
+  }
 }, { immediate: true })
 
 </script>
@@ -44,9 +44,10 @@ watch(() => store.state.isColorblindMode, (newVal) => {
 
 <style>
 body {
-	background-color: var(--dark-blue);
+  background-color: var(--dark-blue);
 }
+
 #app {
-	font-family: 'Open Sans', sans-serif;
+  font-family: 'Open Sans', sans-serif;
 }
 </style>

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { defineEmits, defineProps } from 'vue'
+import { ref, defineEmits, defineProps, onMounted, watch } from 'vue'
 import OperationPipeline from './OperationPipeline.vue'
 import { fetchApiCall, handleError } from '../../utils/api'
 import { calculateColumnSpan } from '../../utils/common'
@@ -15,52 +15,107 @@ const props = defineProps({
 
 const store = useStore()
 const emit = defineEmits(['reloadSession'])
+const images = ref([])
+const filteredImages = ref([])
 
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 const imagesPerRow = 4
+const operationMap = {}
+var selectedOperation = -1
+
+async function addCompletedOperationsOutput() {
+	const url = dataSessionsUrl + props.data.id + '/operations/'
+
+	function updateCompletedOperations(response) {
+		response.results.forEach(operationResponse => {
+			if (operationResponse.status == 'COMPLETED') {
+				addCompletedOperation(operationResponse)
+			}
+		})
+	}
+
+	await fetchApiCall({ url: url, method: 'GET', successCallback: updateCompletedOperations, failCallback: handleError })
+}
+
+
+function imagesContainsFile(file) {
+	return images.value.some(image => image.basename == file.basename && image.source == file.source && image.operation == file.operation)
+}
+
+
+function addCompletedOperation(operationResponse) {
+	if ('output' in operationResponse && 'output_files' in operationResponse.output) {
+		operationResponse.output.output_files.forEach(outputFile => {
+			outputFile.operation = operationResponse.id
+			outputFile.operationIndex = operationMap[operationResponse.id]
+			if (!imagesContainsFile(outputFile)) {
+				images.value.push(outputFile)
+				if (selectedOperation == -1 || selectedOperation == outputFile.operationIndex) {
+					filteredImages.value.push(outputFile)
+				}
+			}
+		})
+	}
+}
+
+
+function selectOperation(operationIndex) {
+	if (operationIndex != selectedOperation){
+		selectedOperation = operationIndex
+		if (selectedOperation == -1){
+			filteredImages.value = images.value
+		}
+		else {
+			filteredImages.value = images.value.filter(image => image.operationIndex == operationIndex)
+		}
+	}
+}
 
 async function addOperation(operationDefinition) {
 	const url = dataSessionsUrl + props.data.id + '/operations/'
-	if ('input_files' in operationDefinition.input_data){
+	if ('input_files' in operationDefinition.input_data) {
 		for (const image of operationDefinition.input_data.input_files) {
 			image.source = 'archive'
 		}
 	}
 
 	// first operation doesn't load unless this is here
-	function postOperationSuccess(){
+	function postOperationSuccess() {
 		emit('reloadSession')
 	}
-	
-	await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: postOperationSuccess, failCallback: handleError})
+
+	await fetchApiCall({ url: url, method: 'POST', body: operationDefinition, successCallback: postOperationSuccess, failCallback: handleError })
 }
+
+watch(() => props.data, () => {
+	props.data.operations.forEach((operation, index) => {
+		operationMap[operation.id] = index
+	})
+}, { immediate: true })
+
+
+onMounted(() => {
+	images.value = [...props.data.input_data]
+	filteredImages.value = [...images.value]
+	addCompletedOperationsOutput()
+})
 
 </script>
 
 <template>
-  <v-container class="d-lg-flex ds-container">
-    <image-grid
-      :data="data"
-      :column-span="calculateColumnSpan(data.input_data.length, imagesPerRow)"
-    />
-    <v-col
-      cols="3"
-      justify="center"
-      align="center"
-    >
-      <!-- The operations bar list goes here -->
-      <operation-pipeline
-        :data="data"
-        :operations="data.operations"
-        @add-operation="addOperation"
-      />
-    </v-col>
-  </v-container>
+	<v-container class="d-lg-flex ds-container">
+		<image-grid :images="filteredImages" :column-span="calculateColumnSpan(data.input_data.length, imagesPerRow)" />
+		<v-col cols="3" justify="center" align="center">
+			<!-- The operations bar list goes here -->
+			<operation-pipeline :images="images" :session_id="data.id" :operations="data.operations"
+				@add-operation="addOperation" @operation-completed="addCompletedOperation" @select-operation="selectOperation"/>
+		</v-col>
+	</v-container>
 </template>
 
 <style scoped>
 .ds-container {
-  background-color: var(--metal);
-  display:flex;
+	background-color: var(--metal);
+	display: flex;
 }
 </style>

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -72,7 +72,6 @@ function selectOperation(operationIndex) {
 }
 
 async function addOperation(operationDefinition) {
-<<<<<<< HEAD
   const url = dataSessionsUrl + props.data.id + '/operations/'
   if ('input_files' in operationDefinition.input_data) {
     for (const image of operationDefinition.input_data.input_files) {
@@ -86,21 +85,6 @@ async function addOperation(operationDefinition) {
   }
 
   await fetchApiCall({ url: url, method: 'POST', body: operationDefinition, successCallback: postOperationSuccess, failCallback: handleError })
-=======
-  const url = dataSessionsUrl + props.data.id + '/operations/'
-  if ('input_files' in operationDefinition.input_data){
-    for (const image of operationDefinition.input_data.input_files) {
-      image.source = 'archive'
-    }
-  }
-
-  // first operation doesn't load unless this is here
-  function postOperationSuccess(){
-    emit('reloadSession')
-  }
-
-  await fetchApiCall({url: url, method: 'POST', body: operationDefinition, successCallback: postOperationSuccess, failCallback: handleError})
->>>>>>> fc904be8a779bf6f16316b0b95400427e2660111
 }
 
 watch(() => props.data, () => {

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -60,9 +60,9 @@ function addCompletedOperation(operationResponse) {
 
 
 function selectOperation(operationIndex) {
-	if (operationIndex != selectedOperation){
+	if (operationIndex != selectedOperation) {
 		selectedOperation = operationIndex
-		if (selectedOperation == -1){
+		if (selectedOperation == -1) {
 			filteredImages.value = images.value
 		}
 		else {
@@ -108,7 +108,7 @@ onMounted(() => {
 		<v-col cols="3" justify="center" align="center">
 			<!-- The operations bar list goes here -->
 			<operation-pipeline :images="images" :session_id="data.id" :operations="data.operations"
-				@add-operation="addOperation" @operation-completed="addCompletedOperation" @select-operation="selectOperation"/>
+				@add-operation="addOperation" @operation-completed="addCompletedOperation" @select-operation="selectOperation" />
 		</v-col>
 	</v-container>
 </template>

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -15,8 +15,8 @@ const props = defineProps({
 
 const store = useStore()
 const emit = defineEmits(['reloadSession'])
-const images = ref([])
-const filteredImages = ref([])
+const images = ref([...props.data.input_data])
+const filteredImages = ref([...images.value])
 
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 const imagesPerRow = 4
@@ -87,16 +87,15 @@ async function addOperation(operationDefinition) {
   await fetchApiCall({ url: url, method: 'POST', body: operationDefinition, successCallback: postOperationSuccess, failCallback: handleError })
 }
 
-watch(() => props.data, () => {
-  props.data.operations.forEach((operation, index) => {
-    operationMap[operation.id] = index
-  })
-}, { immediate: true })
+watch(
+  () => props.data.operations, () => {
+    props.data.operations.forEach((operation, index) => {
+      operationMap[operation.id] = index
+    })
+  }, { immediate: true })
 
 
 onMounted(() => {
-  images.value = [...props.data.input_data]
-  filteredImages.value = [...images.value]
   addCompletedOperationsOutput()
 })
 

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -1,13 +1,13 @@
 <script setup>
-import { ref, onMounted, onUnmounted, computed, defineEmits, defineProps} from 'vue'
+import { ref, onMounted, onUnmounted, computed, defineEmits, defineProps } from 'vue'
 import { fetchApiCall, handleError } from '../../utils/api'
 import { calculateColumnSpan } from '../../utils/common'
 import ImageGrid from '../Global/ImageGrid'
 import { useStore } from 'vuex'
 
-defineProps({
-	data: {
-		type: Object,
+const props = defineProps({
+	images: {
+		type: Array,
 		required: true
 	}
 })
@@ -19,7 +19,7 @@ const dataSessionsUrl = store.state.datalabApiBaseUrl
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
-const selectedDataSessionImages = ref([])
+const selectedImages = ref({})
 const imagesPerRow = ref(3)
 
 const updateImagesPerRow = () => {
@@ -37,8 +37,8 @@ let displayImages = ref(false)
 
 onMounted(async () => {
 	const url = dataSessionsUrl + 'available_operations/'
-	await fetchApiCall({url: url, method: 'GET', successCallback: (data) => {availableOperations.value = data}, failCallback: handleError})
-	if (Object.keys(availableOperations.value).length > 0){
+	await fetchApiCall({ url: url, method: 'GET', successCallback: (data) => { availableOperations.value = data }, failCallback: handleError })
+	if (Object.keys(availableOperations.value).length > 0) {
 		selectOperation(Object.keys(availableOperations.value)[0])
 	}
 	updateImagesPerRow()
@@ -54,12 +54,16 @@ const page = ref('select')
 function selectOperation(name) {
 	selectedOperation.value = name
 	selectedOperationInput.value = {}
+	selectedImages.value = {}
 	for (const [key, value] of Object.entries(selectedOperationInputs.value)) {
-		if ('default' in value){
+		if ('default' in value) {
 			selectedOperationInput.value[key] = value.default
 		}
 		else {
 			selectedOperationInput.value[key] = null
+		}
+		if (value.type == 'file') {
+			selectedImages.value[key] = []
 		}
 	}
 }
@@ -116,220 +120,216 @@ function goForward() {
 		let operationDefinition = {
 			'name': selectedOperation.value,
 			'input_data': {
-				...selectedOperationInput.value,
-				'input_files': selectedDataSessionImages.value
+				...selectedOperationInput.value
 			}
+		}
+		for (const inputKey in selectedImages.value) {
+			let selected = []
+			selectedImages.value[inputKey].forEach(index => {
+				selected.push(props.images[index])
+			})
+			operationDefinition.input_data[inputKey] = selected
 		}
 		emit('addOperation', operationDefinition)
 	}
 }
 
-const handleThumbnailClick = (item) => {
-	const index = selectedDataSessionImages.value.findIndex(selectedImage => selectedImage.basename === item.basename)
-	if (index === -1) {
-		selectedDataSessionImages.value.push(item)
-	} else {
-		selectedDataSessionImages.value.splice(index, 1)
+function selectImage(inputKey, imageIndex) {
+	if (selectedImages.value[inputKey].includes(imageIndex)) {
+		selectedImages.value[inputKey].splice(selectedImages.value[inputKey].indexOf(imageIndex), 1)
+	}
+	else {
+		selectedImages.value[inputKey].push(imageIndex)
 	}
 }
+
+// const handleThumbnailClick = (basename, item) => {
+// 	const index = selectedDataSessionImages.value.findIndex(selectedImage => selectedImage.basename === basename)
+// 	if (index === -1) {
+// 		selectedDataSessionImages.value.push(item)
+// 	} else {
+// 		selectedDataSessionImages.value.splice(index, 1)
+// 	}
+// }
 
 </script>
 
 <template>
-  <v-card class="wizard-background">
-    <v-toolbar class="wizard-toolbar">
-      <v-toolbar-title class="wizard-title">
-        {{ wizardTitle }}
-      </v-toolbar-title>
-    </v-toolbar>
-    <v-card-text v-show="page == 'select'">
-      <v-row>
-        <v-col cols="4">
-          <v-list
-            density="compact"
-            class="wizard-list"
-          >
-            <v-list-subheader class="wizard-subheader">
-              OPERATION
-            </v-list-subheader>
-            <v-list-item
-              v-for="(name, i) in Object.keys(availableOperations)"
-              :key="i"
-              :value="name"
-              :title="name"
-              :active="name == selectedOperation"
-              class="wizard-operations"
-              @click="selectOperation(name)"
-            />
-          </v-list>
-        </v-col>
-        <v-col cols="8">
-          <v-card
-            :title="selectedOperation"
-            class="selected-operation"
-          >
-            <v-card-text>
-              <span class="operation-description">
-                {{ selectedOperationDescription }}
-              </span>
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
-    </v-card-text>
-    <v-slide-y-reverse-transition hide-on-leave>
-      <v-card-text
-        v-show="page == 'configure'"
-        class="wizard-card"
-      >
-        <div
-          v-for="(inputDescription, inputKey) in selectedOperationInputs"
-          :key="inputKey"
-          class="operation-input-wrapper"
-        >
-          <v-text-field
-            v-if="inputDescription.type !== 'file'"
-            v-model="selectedOperationInput[inputKey]"
-            :label="inputDescription.name"
-            :type="inputDescription.type"
-            class="operation-input"
-          />
-          <div
-            v-else-if="inputDescription.type == 'file'"
-            class="images-container"
-          >
-            <image-grid 
-              :data="data"
-              :column-span="calculateColumnSpan(data.input_data.length, imagesPerRow)"
-              :selected-images="selectedDataSessionImages"
-              class="wizard-images"
-              @image-clicked="handleThumbnailClick"
-            />
-          </div>
-        </div>
-      </v-card-text>
-    </v-slide-y-reverse-transition>
+	<v-card class="wizard-background">
+		<v-toolbar class="wizard-toolbar">
+			<v-toolbar-title class="wizard-title">
+				{{ wizardTitle }}
+			</v-toolbar-title>
+		</v-toolbar>
+		<v-card-text v-show="page == 'select'">
+			<v-row>
+				<v-col cols="4">
+					<v-list density="compact" class="wizard-list">
+						<v-list-subheader class="wizard-subheader">
+							OPERATION
+						</v-list-subheader>
+						<v-list-item v-for="(name, i) in Object.keys(availableOperations)" :key="i" :value="name" :title="name"
+							:active="name == selectedOperation" class="wizard-operations" @click="selectOperation(name)" />
+					</v-list>
+				</v-col>
+				<v-col cols="8">
+					<v-card :title="selectedOperation" class="selected-operation">
+						<v-card-text>
+							<span class="operation-description">
+								{{ selectedOperationDescription }}
+							</span>
+						</v-card-text>
+					</v-card>
+				</v-col>
+			</v-row>
+		</v-card-text>
+		<v-slide-y-reverse-transition hide-on-leave>
+			<v-card-text v-show="page == 'configure'" class="wizard-card">
+				<div v-for="(inputDescription, inputKey) in selectedOperationInputs" :key="inputKey"
+					class="operation-input-wrapper">
+					<v-text-field v-if="inputDescription.type !== 'file'" v-model="selectedOperationInput[inputKey]"
+						:label="inputDescription.name" :type="inputDescription.type" class="operation-input" />
+					<div v-else-if="inputDescription.type == 'file'" class="images-container">
+						<image-grid :images="images" :column-span="calculateColumnSpan(images.length, imagesPerRow)"
+							class="wizard-images" :allow-selection="true" @select-image="selectImage(inputKey, $event)" />
+					</div>
+				</div>
+			</v-card-text>
+		</v-slide-y-reverse-transition>
 
-    <v-card-actions class="buttons-container">
-      <v-spacer />
-      <v-btn
-        variant="text"
-        class="goback-btn"
-        @click="goBack"
-      >
-        Go Back
-      </v-btn>
-      <v-btn
-        variant="text"
-        class="gofwd-btn"
-        @click="goForward"
-      >
-        {{ goForwardText }}
-      </v-btn>
-    </v-card-actions>
-  </v-card>
+		<v-card-actions class="buttons-container">
+			<v-spacer />
+			<v-btn variant="text" class="goback-btn" @click="goBack">
+				Go Back
+			</v-btn>
+			<v-btn variant="text" class="gofwd-btn" @click="goForward">
+				{{ goForwardText }}
+			</v-btn>
+		</v-card-actions>
+	</v-card>
 </template>
 
 <style scoped>
-.wizard-background{
-  background-color: var(--dark-blue);
-  height: 100vh;
+.wizard-background {
+	background-color: var(--dark-blue);
+	height: 100vh;
 }
+
 .wizard-toolbar {
-  background-color: var(--metal);
+	background-color: var(--metal);
 }
+
 .wizard-title {
-  color: var(--tan);
-  font-family: 'Open Sans', sans-serif;
-  font-weight: 600;
-  font-size: 1.7rem;
-  letter-spacing: 0.05rem;
-  margin-left: 2%;
+	color: var(--tan);
+	font-family: 'Open Sans', sans-serif;
+	font-weight: 600;
+	font-size: 1.7rem;
+	letter-spacing: 0.05rem;
+	margin-left: 2%;
 }
-.wizard-list{
-  background-color: var(--metal);
+
+.wizard-list {
+	background-color: var(--metal);
 }
+
 .wizard-subheader {
-  color: var(--tan);
-  font-weight: 500;
-  letter-spacing: 0.05rem;
-  font-size: 1.4rem;
+	color: var(--tan);
+	font-weight: 500;
+	letter-spacing: 0.05rem;
+	font-size: 1.4rem;
 }
+
 .wizard-operations {
-  color: var(--tan);
+	color: var(--tan);
 }
+
 .selected-operation {
-  color: var(--tan);
-  background-color: var(--metal);
-  text-transform: uppercase;
-  font-family: 'Open Sans', sans-serif;
-  font-size: 3rem;
+	color: var(--tan);
+	background-color: var(--metal);
+	text-transform: uppercase;
+	font-family: 'Open Sans', sans-serif;
+	font-size: 3rem;
 }
-.operation-description{
-  font-size: 1rem;
+
+.operation-description {
+	font-size: 1rem;
 }
+
 .wizard-card {
-  width: 100%; 
-  display: flex;
-  flex-direction: column-reverse;
+	width: 100%;
+	display: flex;
+	flex-direction: column-reverse;
 }
+
 .images-container {
-  display: flex;
-  flex-wrap: wrap; 
-  justify-content: flex-start; 
-  width: 100%; 
-  padding-left: 2rem; 
-  padding-right: 2rem; 
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	width: 100%;
+	padding-left: 2rem;
+	padding-right: 2rem;
 }
+
 .wizard-images {
-  max-width: 100%; 
-  height: auto; 
-  box-sizing: border-box; 
-  cursor: pointer;
+	max-width: 100%;
+	height: auto;
+	box-sizing: border-box;
+	cursor: pointer;
 }
+
 .selected-image {
-  border: 0.3rem solid var(--dark-green);
+	border: 0.3rem solid var(--dark-green);
 }
+
 .operation-input {
-  width: 10vw;
-  margin-left: 2%;
-  margin-bottom: 2%;
-  background-color: var(--metal);
+	width: 10vw;
+	margin-left: 2%;
+	margin-bottom: 2%;
+	background-color: var(--metal);
 }
+
 .buttons-container {
-  position: fixed;
-  right: 2rem;
-  bottom: 2rem;
+	position: fixed;
+	right: 2rem;
+	bottom: 2rem;
 }
+
 .goback-btn {
-  color: var(--cancel);
-  font-size: 1.2rem;
+	color: var(--cancel);
+	font-size: 1.2rem;
 }
-.gofwd-btn{
-  color:var(--light-blue);
-  font-size: 1.2rem;
+
+.gofwd-btn {
+	color: var(--light-blue);
+	font-size: 1.2rem;
 }
+
 @media (max-width: 1200px) {
-.operation-input {
-  margin-left: 3%;
+	.operation-input {
+		margin-left: 3%;
+	}
+
+	.images-container {
+		margin-top: 2%;
+	}
 }
-.images-container {
-  margin-top: 2%;
-}
-}
+
 @media (max-width: 900px) {
-.selected-operation {
-  height: 120%;
-}
-.operation-description{
-  font-size: 1rem;
-}
-.operation-input {
-  margin-left: 4%;
-  width: 15vw;
-}
-.images-container {
-  margin-top: 3%;
-}
+	.selected-operation {
+		height: 120%;
+	}
+
+	.operation-description {
+		font-size: 1rem;
+	}
+
+	.operation-input {
+		margin-left: 4%;
+		width: 15vw;
+	}
+
+	.images-container {
+		margin-top: 3%;
+	}
 }
 </style>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -1,79 +1,88 @@
 <script setup>
-import { defineProps, ref, defineEmits, onMounted } from 'vue'
+import { defineProps, ref, defineEmits, watch } from 'vue'
 import { useStore } from 'vuex'
 import { fetchApiCall, handleError } from '../../utils/api'
 
 const props = defineProps({
-	data: {
-		type: Object,
+	images: {
+		type: Array,
 		required: true
 	},
 	columnSpan: {
 		type: Number,
 		required: true
 	},
-	// eslint-disable-next-line vue/require-default-prop
-	selectedImages: Array
+	allowSelection: {
+		type: Boolean,
+		default: false
+	}
 })
 
-const emit = defineEmits(['imageClicked'])
-
-let images = ref([])
+let imageDetails = ref({})
+let selectedImages = ref([])
 const store = useStore()
+const emit = defineEmits(['selectImage'])
 
-const saveImages = (data) => {
+const saveImage = (data) => {
 	const results = data.results
 	if (results.length) {
-		images.value.push(data.results[0])
+		const imageBasename = data.results[0].basename.replace('-small', '')
+		imageDetails.value[imageBasename] = data.results[0]
 	}
 }
 
-const getImages = async () => {
-	const responseData = props.data
-	const inputData = responseData.input_data
-	for (const data of inputData) {
-		const basename = data.basename
-		const url =  store.state.datalabArchiveApiUrl + 'frames/?basename_exact=' + basename + '-small'
-		await fetchApiCall({url: url, method: 'GET', successCallback: saveImages, failCallback: handleError})
+async function loadImage(basename) {
+	const url = store.state.datalabArchiveApiUrl + 'frames/?basename_exact=' + basename + '-small'
+	await fetchApiCall({ url: url, method: 'GET', successCallback: saveImage, failCallback: handleError })
+}
+
+const isSelected = (index) => {
+	return selectedImages.value.includes(index)
+}
+
+const onImageClick = (index) => {
+	if (props.allowSelection) {
+		if (selectedImages.value.includes(index)) {
+			selectedImages.value.splice(selectedImages.value.indexOf(index), 1)
+		}
+		else {
+			selectedImages.value.push(index)
+		}
+		emit('selectImage', index)
 	}
 }
 
-const isSelected = (image) => {
-	return props.selectedImages?.some(selectedImage => selectedImage.basename === image.basename)
-}
-
-const onImageClick = (image) => {
-	emit('imageClicked', image)
-}
-
-onMounted(() => {
-	getImages()
-})
+watch(() => props.images, () => {
+	selectedImages.value = []
+	props.images.forEach(image => {
+		if (!(image.basename in imageDetails.value)) {
+			loadImage(image.basename)
+		}
+	})
+}, { immediate: true })
 
 </script>
 
 <template>
-  <v-row v-if="images.length">
-    <v-col
-      v-for="image of images"
-      :key="image.basename"
-      :cols="columnSpan"
-    >
-      <v-img
-        :src="image.url"
-        :alt="image.basename"
-        :images="images"
-        cover
-        :class="{ 'selected-image': isSelected(image) }"
-        aspect-ratio="1"
-        @click="onImageClick(image)"
-      />
-    </v-col>
-  </v-row>
+	<v-row v-if="props.images.length">
+		<v-col v-for="(image, index) in props.images" :key="index" :cols="columnSpan">
+			<v-img v-if="image.basename in imageDetails" :src="imageDetails[image.basename].url" :alt="image.basename" cover
+				:class="{ 'selected-image': isSelected(index) }" aspect-ratio="1" @click="onImageClick(index)">
+				<span v-if="'operationIndex' in image" class="image-text-overlay">{{ image.operationIndex }}</span>
+			</v-img>
+		</v-col>
+	</v-row>
 </template>
 
 <style scoped>
 .selected-image {
-  border: 0.3rem solid var(--dark-green);
+	border: 0.3rem solid var(--dark-green);
+}
+
+.image-text-overlay {
+  color: white;
+  font-weight: bold;
+  margin-right: 5px;
+  float: right;
 }
 </style>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -15,53 +15,53 @@ const deleteSessionId = ref(-1)
 const showDeleteDialog = ref(false)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 
-onBeforeMount(()=>{
-	if(!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
+onBeforeMount(() => {
+  if (!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
 })
 
 onMounted(async () => {
-	await loadSessions()
-	// if user created or selected a specific datasession, load that tab
-	if (route.params.sessionId && dataSessions.value.some(ds => ds.id == route.params.sessionId)) {
-		tab.value = Number(route.params.sessionId)
-		// if user is navigating to just /datasessions then their first datasession loads and adds /[first id] as params
-	} else {
-		if (dataSessions.value.length > 0) {
-			const firstSessionId = dataSessions.value[0].id
-			tab.value = firstSessionId
-		} else {
-			console.log('no data sessions available to display')
-		}
-	}
+  await loadSessions()
+  // if user created or selected a specific datasession, load that tab
+  if (route.params.sessionId && dataSessions.value.some(ds => ds.id == route.params.sessionId)) {
+    tab.value = Number(route.params.sessionId)
+    // if user is navigating to just /datasessions then their first datasession loads and adds /[first id] as params
+  } else {
+    if (dataSessions.value.length > 0) {
+      const firstSessionId = dataSessions.value[0].id
+      tab.value = firstSessionId
+    } else {
+      console.log('no data sessions available to display')
+    }
+  }
 })
 
 function onTabChange(newSessionId) {
-	tab.value = newSessionId
+  tab.value = newSessionId
 }
 
 function openDeleteDialog(id) {
-	deleteSessionId.value = id
-	showDeleteDialog.value = true
+  deleteSessionId.value = id
+  showDeleteDialog.value = true
 }
 
 async function loadSessions() {
-	await fetchApiCall({url: dataSessionsUrl, method: 'GET', successCallback: updateData, failCallback: handleError})
+  await fetchApiCall({ url: dataSessionsUrl, method: 'GET', successCallback: updateData, failCallback: handleError })
 }
 
 // if tab is not in new data default to displaying first tab
 function updateData(data) {
-	dataSessions.value = data.results
-	if(!dataSessions.value.some(ds => ds.id == tab.value)){
-		tab.value = dataSessions.value[0]?.id
-	}
+  dataSessions.value = data.results
+  if (!dataSessions.value.some(ds => ds.id == tab.value)) {
+    tab.value = dataSessions.value[0]?.id
+  }
 }
 
 function tabColor(index) {
-	if (dataSessions.value[index] && tab.value === dataSessions.value[index].id) {
-		return 'selected'
-	} else {
-		return 'not-selected'
-	}
+  if (dataSessions.value[index] && tab.value === dataSessions.value[index].id) {
+    return 'selected'
+  } else {
+    return 'not-selected'
+  }
 }
 
 </script>
@@ -69,55 +69,22 @@ function tabColor(index) {
 <template>
   <v-container class="d-lg datasession-container">
     <v-card>
-      <v-tabs 
-        v-model="tab"
-        class="tabs"
-        next-icon="mdi-arrow-right-bold-box-outline"
-        prev-icon="mdi-arrow-left-bold-box-outline"
-        show-arrows
-        @update:model-value="onTabChange"
-      >
-        <v-tab
-          v-for="(ds, index) in dataSessions"
-          :key="ds.id"
-          :value="ds.id"
-          :class="tabColor(index)"
-          class="pr-0 tab"
-        >
+      <v-tabs v-model="tab" class="tabs" next-icon="mdi-arrow-right-bold-box-outline"
+        prev-icon="mdi-arrow-left-bold-box-outline" show-arrows @update:model-value="onTabChange">
+        <v-tab v-for="(ds, index) in dataSessions" :key="ds.id" :value="ds.id" :class="tabColor(index)" class="pr-0 tab">
           {{ ds.name }}
-          <v-btn
-            variant="text"
-            icon="mdi-close"
-            class="tab_button"
-            :class="tabColor(index)"
-            @click="openDeleteDialog(ds.id)"
-          />
+          <v-btn variant="text" icon="mdi-close" class="tab_button" :class="tabColor(index)"
+            @click="openDeleteDialog(ds.id)" />
         </v-tab>
-        <v-btn
-          variant="plain"
-          icon="mdi-plus-box"
-          class="tab_button"
-          @click="router.push({ name: 'ProjectView' })"
-        />
+        <v-btn variant="plain" icon="mdi-plus-box" class="tab_button" @click="router.push({ name: 'ProjectView' })" />
       </v-tabs>
       <v-window v-model="tab">
-        <v-window-item
-          v-for="ds in dataSessions"
-          :key="ds.id"
-          :value="ds.id"
-        >
-          <data-session
-            :data="ds"
-            @reload-session="loadSessions()"
-          />
+        <v-window-item v-for="ds in dataSessions" :key="ds.id" :value="ds.id">
+          <data-session :data="ds" @reload-session="loadSessions()" />
         </v-window-item>
       </v-window>
     </v-card>
-    <delete-session-dialog
-      v-model="showDeleteDialog"
-      :delete-id="deleteSessionId"
-      @reload-session="loadSessions()"
-    />
+    <delete-session-dialog v-model="showDeleteDialog" :delete-id="deleteSessionId" @reload-session="loadSessions()" />
   </v-container>
 </template>
 
@@ -126,6 +93,7 @@ function tabColor(index) {
   background-color: var(--metal);
   border-bottom: 0.1rem solid var(--tan);
 }
+
 .tab {
   font-size: 1.2rem;
   text-decoration: none;
@@ -133,30 +101,37 @@ function tabColor(index) {
   font-weight: 600;
   background-color: var(--metal);
 }
+
 .tab_button {
   color: var(--tan);
   text-decoration: none;
   margin: 0 0.5rem;
 }
-.selected { 
+
+.selected {
   background-color: var(--light-blue);
   color: white;
 }
+
 .not-selected {
   background-color: var(--metal);
 }
+
 @media (max-width: 1200px) {
-.datasession-container {
-  width: 85vw;
-  justify-content: left;
-}
+  .datasession-container {
+    width: 85vw;
+    justify-content: left;
+  }
+
   .tab {
     font-size: 0.85rem;
   }
+
   .tab_button {
     margin: 0;
   }
 }
+
 @media (max-width: 900px) {
   .datasession-container {
     width: 80vw;

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -16,8 +16,8 @@ const errorMessage = ref('')
 const isLoading = ref(true)
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
 
-onBeforeMount(()=>{
-	if(!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
+onBeforeMount(() => {
+  if (!store.getters['userData/userIsAuthenticated']) router.push({ name: 'Registration' })
 })
 
 // toggle for optional data viewing, controlled by a v-switch
@@ -29,135 +29,135 @@ const selectedProjectImages = ref([])
 
 // Loads the user's Images from their profile into userImages ( currently just fetches all frames from archive regardless of proposal )
 const loadUserImages = async (option) => {
-	isLoading.value = true
-	await store.dispatch('loadAndCacheImages', { option })
-	isLoading.value = false
-	smallImageCache.value = store.state.smallImageCache
-	updateGroupedProjects()
+  isLoading.value = true
+  await store.dispatch('loadAndCacheImages', { option })
+  isLoading.value = false
+  smallImageCache.value = store.state.smallImageCache
+  updateGroupedProjects()
 }
 
 // groups all projects by proposal id
 function groupByProposalId() {
-	if (smallImageCache.value) {
-		return smallImageCache.value.reduce((acc, project) => {
-			if (!acc[project.proposal_id]) {
-				acc[project.proposal_id] = []
-			}
-			acc[project.proposal_id].push(project)
-			return acc
-		}, {})
-	}
+  if (smallImageCache.value) {
+    return smallImageCache.value.reduce((acc, project) => {
+      if (!acc[project.proposal_id]) {
+        acc[project.proposal_id] = []
+      }
+      acc[project.proposal_id].push(project)
+      return acc
+    }, {})
+  }
 }
 
 // sorts projects by group id and handles selectedproject as the first one for when the page first loads 
 function updateGroupedProjects() {
-	projects.value = groupByProposalId(smallImageCache.value)
-	const firstProjectKey = Object.keys(projects.value)[0]
-	if (firstProjectKey) {
-		const firstProjectProposalIds = [firstProjectKey]
-		filterImagesByProposalId(firstProjectProposalIds)
-	}
+  projects.value = groupByProposalId(smallImageCache.value)
+  const firstProjectKey = Object.keys(projects.value)[0]
+  if (firstProjectKey) {
+    const firstProjectProposalIds = [firstProjectKey]
+    filterImagesByProposalId(firstProjectProposalIds)
+  }
 }
 
 // handles the selected project to filter images that only have the selected proposal_id
 const filterImagesByProposalId = (proposalId) => {
-	selectedProjectImages.value = smallImageCache.value.filter(image => proposalId.includes(image.proposal_id))
+  selectedProjectImages.value = smallImageCache.value.filter(image => proposalId.includes(image.proposal_id))
 }
 
 // boolean computed property used to disable the add to session button
 const noSelectedImages = computed(() => {
-	return store.getters.selectedImages.length === 0
+  return store.getters.selectedImages.length === 0
 })
 
 // manages successful api response by mapping data to unique sessions
 const mapDataSessions = (data) => {
-	const results = data.results
-	uniqueDataSessions.value = results
-		.map(session => ({ id: session.id, name: session.name }))
-	isPopupVisible.value = true
+  const results = data.results
+  uniqueDataSessions.value = results
+    .map(session => ({ id: session.id, name: session.name }))
+  isPopupVisible.value = true
 }
 
 // manages api call failures by logging errors
 const handleError = (error) => {
-	console.error('API call failed with error:', error)
-	errorMessage.value = error.message || 'An error occurred'
+  console.error('API call failed with error:', error)
+  errorMessage.value = error.message || 'An error occurred'
 }
 
 // fetches session data from API and handles response or error using the callbacks
 const getDataSessions = async () => {
-	await fetchApiCall({ url: dataSessionsUrl, method: 'GET', successCallback: mapDataSessions, failCallback: handleError })
+  await fetchApiCall({ url: dataSessionsUrl, method: 'GET', successCallback: mapDataSessions, failCallback: handleError })
 }
 
 // updates an existing session with selected images
 const addImagesToExistingSession = async (session) => {
-	const sessionIdUrl = dataSessionsUrl + session.id + '/'
-	// fetches existing session data
-	const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
-	if (currentSessionResponse) {
-		const currentSessionData = currentSessionResponse.input_data
-		// merging existing and new image data
-		// this is temporary since the backend has to be updated to handle this
-		// remove this when backend gets updated
-		const selectedImages = store.state.selectedImages
-		const inputData = [...currentSessionData, ...selectedImages.map(image => ({
-			'source': 'archive',
-			'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
-		}))]
-		const requestBody = {
-			'name': session.name,
-			'input_data': inputData
-		}
+  const sessionIdUrl = dataSessionsUrl + session.id + '/'
+  // fetches existing session data
+  const currentSessionResponse = await fetchApiCall({ url: sessionIdUrl, method: 'GET' })
+  if (currentSessionResponse) {
+    const currentSessionData = currentSessionResponse.input_data
+    // merging existing and new image data
+    // this is temporary since the backend has to be updated to handle this
+    // remove this when backend gets updated
+    const selectedImages = store.state.selectedImages
+    const inputData = [...currentSessionData, ...selectedImages.map(image => ({
+      'source': 'archive',
+      'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
+    }))]
+    const requestBody = {
+      'name': session.name,
+      'input_data': inputData
+    }
 
-		// sending the PATCH request with the merged data
-		await fetchApiCall({ url: sessionIdUrl, method: 'PATCH', body: requestBody })
-	} else {
-		handleError()
-	}
+    // sending the PATCH request with the merged data
+    await fetchApiCall({ url: sessionIdUrl, method: 'PATCH', body: requestBody })
+  } else {
+    handleError()
+  }
 }
 
 // closes popup, invokes addImagesToExistingSession, and reroutes user to DataSessions view
 const selectDataSession = async (session) => {
-	isPopupVisible.value = false
-	await addImagesToExistingSession(session)
-	router.push({ name: 'DataSessionDetails', params: { sessionId: session.id } })
+  isPopupVisible.value = false
+  await addImagesToExistingSession(session)
+  router.push({ name: 'DataSessionDetails', params: { sessionId: session.id } })
 
 }
 
 // handles creation of a new session 
-const createNewDataSession = async () => { 
-	if (sessionNameExists(newSessionName.value)) {
-		errorMessage.value = 'Data Session name already exists. Please choose a different name.'
-		return
-	}
-	const selectedImages = store.state.selectedImages
-	const inputData = selectedImages.map(image => ({
-		'source': 'archive',
-		'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
-	}))
-	const requestBody = { 
-		'name': newSessionName.value,
-		'input_data': inputData 
-	}
+const createNewDataSession = async () => {
+  if (sessionNameExists(newSessionName.value)) {
+    errorMessage.value = 'Data Session name already exists. Please choose a different name.'
+    return
+  }
+  const selectedImages = store.state.selectedImages
+  const inputData = selectedImages.map(image => ({
+    'source': 'archive',
+    'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
+  }))
+  const requestBody = {
+    'name': newSessionName.value,
+    'input_data': inputData
+  }
 
-	// attempting a POST request for new session
-	const response = await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody })
-	if (response) {
-		isPopupVisible.value = false
-		newSessionName.value = ''
-		errorMessage.value = ''
-		router.push({ name: 'DataSessionDetails', params: { sessionId: response.id } })
-	} else {
-		errorMessage.value = 'Error creating new data session'
-	}
+  // attempting a POST request for new session
+  const response = await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody })
+  if (response) {
+    isPopupVisible.value = false
+    newSessionName.value = ''
+    errorMessage.value = ''
+    router.push({ name: 'DataSessionDetails', params: { sessionId: response.id } })
+  } else {
+    errorMessage.value = 'Error creating new data session'
+  }
 }
 
 const sessionNameExists = (name) => {
-	return uniqueDataSessions.value.some(session => session.name === name)
+  return uniqueDataSessions.value.some(session => session.name === name)
 }
 
 onMounted(() => {
-	loadUserImages('reduction_level=95')
-	loadUserImages('reduction_level=96')
+  loadUserImages('reduction_level=95')
+  loadUserImages('reduction_level=96')
 })
 
 </script>
@@ -165,102 +165,53 @@ onMounted(() => {
 <template>
   <!-- only load if config is loaded -->
   <div class="container">
-    <ProjectBar
-      class="project-bar"
-      :projects="projects"
-      @selected-project="filterImagesByProposalId"
-    />
+    <ProjectBar class="project-bar" :projects="projects" @selected-project="filterImagesByProposalId" />
     <div class="image-area h-screen">
-      <div
-        v-if="isLoading"
-        class="loading-indicator-container"
-      >
-        <v-progress-circular
-          indeterminate
-          model-value="20"
-          :size="50"
-          :width="9"
-        />
+      <div v-if="isLoading" class="loading-indicator-container">
+        <v-progress-circular indeterminate model-value="20" :size="50" :width="9" />
       </div>
 
       <div v-else>
-        <ImageCarousel
-          v-if="imageDisplayToggle && selectedProjectImages.length"
-          :data="selectedProjectImages"
-        />
-        <ImageList
-          v-if="!imageDisplayToggle && selectedProjectImages.length"
-          :data="selectedProjectImages"
-        />
+        <ImageCarousel v-if="imageDisplayToggle && selectedProjectImages.length" :data="selectedProjectImages" />
+        <ImageList v-if="!imageDisplayToggle && selectedProjectImages.length" :data="selectedProjectImages" />
         <p v-if="!selectedProjectImages.length">
           Please create a project to use Datalab
         </p>
       </div>
-      <v-skeleton-loader
-        v-if="!store.state.smallImageCache"
-        type="card"
-      />
+      <v-skeleton-loader v-if="!store.state.smallImageCache" type="card" />
       <div class="control-buttons">
-        <v-switch
-          v-model="imageDisplayToggle"
-          class="d-flex mr-4"
-          inset
-          prepend-icon="mdi-view-list"
-          append-icon="mdi-image"
-        />
-        <v-btn
-          :disabled="noSelectedImages"
-          class="add_button"
-          @click="getDataSessions"
-        >
+        <v-switch v-model="imageDisplayToggle" class="d-flex mr-4" inset prepend-icon="mdi-view-list"
+          append-icon="mdi-image" />
+        <v-btn :disabled="noSelectedImages" class="add_button" @click="getDataSessions">
           Add to a Session
         </v-btn>
       </div>
     </div>
   </div>
-  <v-dialog
-    v-model="isPopupVisible"
-    width="300"
-  >
+  <v-dialog v-model="isPopupVisible" width="300">
     <v-card class="card">
       <v-card-title class="sessions_header">
         DATA SESSIONS
       </v-card-title>
       <v-card-text>
         <v-list>
-          <v-list-item
-            v-for="session in uniqueDataSessions"
-            :key="session.id"
-            class="sessions"
-            @click="selectDataSession(session)"
-          >
+          <v-list-item v-for="session in uniqueDataSessions" :key="session.id" class="sessions"
+            @click="selectDataSession(session)">
             {{ session.name }}
           </v-list-item>
         </v-list>
         <!-- Input for new session name -->
-        <v-text-field
-          v-model="newSessionName"
-          label="New Session Name"
-          class="sessions"
-        />
+        <v-text-field v-model="newSessionName" label="New Session Name" class="sessions" />
         <!-- Error message -->
         <div v-if="errorMessage">
           {{ errorMessage }}
         </div>
       </v-card-text>
       <v-card-actions>
-        <v-btn
-          text
-          class="button create_button"
-          @click="createNewDataSession"
-        >
+        <v-btn text class="button create_button" @click="createNewDataSession">
           Create New Session
         </v-btn>
-        <v-btn
-          text
-          class="button cancel_button"
-          @click="isPopupVisible = false"
-        >
+        <v-btn text class="button cancel_button" @click="isPopupVisible = false">
           Close
         </v-btn>
       </v-card-actions>
@@ -268,18 +219,20 @@ onMounted(() => {
   </v-dialog>
 </template>
 <style scoped>
-.container{
+.container {
   margin: 0;
   display: grid;
   grid-template-columns: [col1-start] 1fr [col1-end col2-start] 80% [col2-end];
   grid-template-rows: [row-start] 100% [row-end];
   height: 100vh;
 }
-.card{
+
+.card {
   height: 450px;
   width: 700px;
   align-self: center;
 }
+
 .sessions_header {
   font-family: 'Open Sans', sans-serif;
   font-size: 1.6rem;
@@ -289,13 +242,15 @@ onMounted(() => {
   font-weight: 600;
   letter-spacing: 0.05rem;
 }
+
 .loading-indicator-container {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100%;
 }
-.project-bar{
+
+.project-bar {
   display: flex;
   grid-column-start: col1-start;
   grid-column-end: col1-end;
@@ -303,6 +258,7 @@ onMounted(() => {
   grid-row-end: row-end;
   height: 50%;
 }
+
 .add_button {
   width: 16rem;
   height: 4rem;
@@ -314,30 +270,36 @@ onMounted(() => {
   font-weight: 700;
   color: white;
 }
+
 .add_button:disabled {
-  background-color:var(--light-blue);
-  color: white;  
+  background-color: var(--light-blue);
+  color: white;
   opacity: calc(0.7);
 }
+
 .button {
   font-family: 'Open Sans', sans-serif;
   font-size: 1.4rem;
   padding: 0 1rem;
   margin-bottom: 1rem;
 }
+
 .create_button {
   color: var(--light-blue);
   font-weight: 700;
 }
+
 .cancel_button {
   color: var(--cancel);
   font-weight: 700;
   padding-left: 38%;
 }
+
 .image-area {
   grid-column-start: col2-start;
   grid-column-end: col2-end;
 }
+
 .control-buttons {
   margin-top: 10px;
   display: flex;
@@ -348,50 +310,60 @@ onMounted(() => {
   bottom: 2%;
   right: 3%;
 }
+
 .sessions {
   font-family: 'Open Sans', sans-serif;
   color: var(--tan);
   font-size: 1.5rem;
 }
+
 @media (max-width: 1200px) {
   .card {
     height: 55vh;
     width: 30vw;
     align-self: center;
   }
+
   .sessions_header {
     font-size: 1.2rem;
     padding: 0.8rem;
   }
+
   .add_button {
     width: 12rem;
     height: 3rem;
     font-size: 1rem;
   }
+
   .project-bar {
     height: 60%;
   }
+
   .button {
     font-family: 'Open Sans', sans-serif;
     font-size: 1rem;
     padding: 0 1rem;
     margin-bottom: 1rem;
   }
+
   .sessions {
     font-family: 'Open Sans', sans-serif;
     font-size: 0.85rem;
   }
 }
+
 @media (max-width: 900px) {
   .card {
     width: 40vw;
     height: 35vh;
-  } 
+  }
+
   .add_button {
     width: 22vw;
     height: 4.8vh;
     font-size: 1rem;
-  } 
+  }
+
   .project-bar {
     height: 35vh;
     width: 25vw;

--- a/src/views/RegistrationView.vue
+++ b/src/views/RegistrationView.vue
@@ -12,43 +12,43 @@ const password = ref('')
 const errorMessage = ref('')
 const showPassword = ref(false)
 
-onBeforeMount(()=>{
-	if(store.getters['userData/userIsAuthenticated']) router.push({ name: 'ProjectView' })
+onBeforeMount(() => {
+  if (store.getters['userData/userIsAuthenticated']) router.push({ name: 'ProjectView' })
 })
 
 // validation rule for vuetify components
 // we can add rules here in the future for passwords
 const rules = {
-	required: value => !!value || 'Required.'
+  required: value => !!value || 'Required.'
 }
 
 const storeToken = async (data) => {
-	const authToken = data.token
-	if (authToken) {
-		store.dispatch('userData/setAuthToken', authToken)
-		await fetchApiCall({ url: store.state.observationPortalUrl + 'profile/', method: 'GET', successCallback: storeUser, failCallback: handleError })
-	}
+  const authToken = data.token
+  if (authToken) {
+    store.dispatch('userData/setAuthToken', authToken)
+    await fetchApiCall({ url: store.state.observationPortalUrl + 'profile/', method: 'GET', successCallback: storeUser, failCallback: handleError })
+  }
 }
 
 const handleError = (error) => {
-	console.error('API call failed with error:', error)
-	errorMessage.value = 'Failed to authenticate user'
+  console.error('API call failed with error:', error)
+  errorMessage.value = 'Failed to authenticate user'
 }
 
 const storeUser = (user) => {
-	store.dispatch('userData/setUsername', username.value)
-	store.dispatch('userData/setUserProfile', user)
-	store.commit('setProjects', user.proposals)
-	router.push({ name: 'ProjectView' })
+  store.dispatch('userData/setUsername', username.value)
+  store.dispatch('userData/setUserProfile', user)
+  store.commit('setProjects', user.proposals)
+  router.push({ name: 'ProjectView' })
 }
 
 const Login = async () => {
-	const requestBody = {
-		username: username.value,
-		password: password.value
-	}
-	// store an auth token from login credentials
-	await fetchApiCall({ url: store.state.observationPortalUrl + 'api-token-auth/', method: 'POST', body: requestBody, successCallback: storeToken, failCallback: handleError })
+  const requestBody = {
+    username: username.value,
+    password: password.value
+  }
+  // store an auth token from login credentials
+  await fetchApiCall({ url: store.state.observationPortalUrl + 'api-token-auth/', method: 'POST', body: requestBody, successCallback: storeToken, failCallback: handleError })
 }
 
 </script>
@@ -57,44 +57,19 @@ const Login = async () => {
   <v-container class="registration-container">
     <v-card class="login-card pa-10">
       <div class="login-title">
-        <img
-          class="lambdaLogo"
-          :src="lambdaLogo"
-        >
+        <img class="lambdaLogo" :src="lambdaLogo">
         <h1>Datalab</h1>
       </div>
-      <v-form
-        class="pt-7"
-        @submit.prevent="Login"
-      >
-        <v-text-field
-          v-model="username"
-          autocomplete="username"
-          label="Username"
-          :rules="[rules.required]"
-          required
-        />
+      <v-form class="pt-7" @submit.prevent="Login">
+        <v-text-field v-model="username" autocomplete="username" label="Username" :rules="[rules.required]" required />
 
-        <v-text-field
-          v-model="password"
-          autocomplete="current-password"
-          label="Password"
-          :type="showPassword ? 'text' : 'password'"
-          :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-          :rules="[rules.required]"
-          required
-          @click:append="showPassword = !showPassword"
-        />
-        <v-btn
-          type="submit"
-          color="primary"
-        >
+        <v-text-field v-model="password" autocomplete="current-password" label="Password"
+          :type="showPassword ? 'text' : 'password'" :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+          :rules="[rules.required]" required @click:append="showPassword = !showPassword" />
+        <v-btn type="submit" color="primary">
           Login
         </v-btn>
-        <div
-          v-if="errorMessage"
-          class="error-message"
-        >
+        <div v-if="errorMessage" class="error-message">
           {{ errorMessage }}
         </div>
       </v-form>
@@ -103,7 +78,7 @@ const Login = async () => {
 </template>
 
 <style scoped>
-.registration-container{
+.registration-container {
   height: 100%;
   display: flex;
   justify-content: center;
@@ -111,19 +86,23 @@ const Login = async () => {
   align-items: center;
 
 }
-.login-card{
+
+.login-card {
   width: 500px;
 }
-.lambdaLogo{
+
+.lambdaLogo {
   height: 1.8em;
   margin-right: 10px;
 }
-.login-title{
+
+.login-title {
   display: flex;
   align-items: center;
 }
+
 .error-message {
-    color: red;
-    margin-top: 10px;
+  color: red;
+  margin-top: 10px;
 }
 </style>


### PR DESCRIPTION
CAROLINA WAKE UP and review this PR!!!

I'm not going to include a video, you can run it locally if you want. It adds the output images to the DataSession view, and it refactors the ImageGrid a bit to work generically with operation file inputs (not just those with key "input_files"), shows the operation that the image is from with operation Index in the upper right corner of the image (if it is output of an operation), and selection/image input is changed so that the correct image payload is sent to the server on selection. Also datasession view images can be filtered when clicking on an operation now.

There are so many changes because I had to run the auto-formatting on the files since it got mad that I dared to use spaces instead of tabs...
