### PR TITLE
Styling/fix image sizing

### DIFF
--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -2,7 +2,6 @@
 import { defineEmits, defineProps } from 'vue'
 import OperationPipeline from './OperationPipeline.vue'
 import { fetchApiCall, handleError } from '../../utils/api'
-import { calculateColumnSpan } from '../../utils/common'
 import { useStore } from 'vuex'
 import ImageGrid from '../Global/ImageGrid'
 
@@ -17,7 +16,6 @@ const store = useStore()
 const emit = defineEmits(['reloadSession'])
 
 const dataSessionsUrl = store.state.datalabApiBaseUrl + 'datasessions/'
-const imagesPerRow = 4
 
 async function addOperation(operationDefinition) {
   const url = dataSessionsUrl + props.data.id + '/operations/'
@@ -41,7 +39,6 @@ async function addOperation(operationDefinition) {
   <v-container class="d-lg-flex ds-container">
     <image-grid
       :data="data"
-      :column-span="calculateColumnSpan(data.input_data.length, imagesPerRow)"
     />
     <v-col
       cols="3"

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -1,7 +1,6 @@
 <script setup>
-import { ref, onMounted, onUnmounted, computed, defineEmits, defineProps} from 'vue'
+import { ref, onMounted, computed, defineEmits, defineProps} from 'vue'
 import { fetchApiCall, handleError } from '../../utils/api'
-import { calculateColumnSpan } from '../../utils/common'
 import ImageGrid from '../Global/ImageGrid'
 import { useStore } from 'vuex'
 
@@ -20,19 +19,6 @@ const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedDataSessionImages = ref([])
-const imagesPerRow = ref(3)
-
-const updateImagesPerRow = () => {
-  const width = window.innerWidth
-  if (width >= 1200) {
-    imagesPerRow.value = 5
-  } else if (width >= 900) {
-    imagesPerRow.value = 4
-  } else {
-    imagesPerRow.value = 3
-  }
-}
-
 let displayImages = ref(false)
 
 onMounted(async () => {
@@ -41,12 +27,6 @@ onMounted(async () => {
   if (Object.keys(availableOperations.value).length > 0){
     selectOperation(Object.keys(availableOperations.value)[0])
   }
-  updateImagesPerRow()
-  window.addEventListener('resize', updateImagesPerRow)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('resize', updateImagesPerRow)
 })
 
 const page = ref('select')
@@ -200,7 +180,6 @@ const handleThumbnailClick = (item) => {
           >
             <image-grid 
               :data="data"
-              :column-span="calculateColumnSpan(data.input_data.length, imagesPerRow)"
               :selected-images="selectedDataSessionImages"
               class="wizard-images"
               @image-clicked="handleThumbnailClick"

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -63,6 +63,7 @@ onMounted(() => {
         cover
         :class="{ 'selected-image': isSelected(image) }"
         aspect-ratio="1"
+        class="image-grid"
         @click="onImageClick(image)"
       />
     </v-col>
@@ -72,8 +73,15 @@ onMounted(() => {
 <style scoped>
 .image-grid-container {
   display: flex;
+  max-width: 200px;
+  max-height: 200px;
 }
 .selected-image {
   border: 0.3rem solid var(--dark-green);
+}
+.image-grid {
+  max-width: 200px;
+  height: auto;
+  
 }
 </style>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -82,6 +82,11 @@ onMounted(() => {
 .image-grid {
   max-width: 200px;
   height: auto;
-  
+}
+@media (max-width: 900px) {
+.image-grid {
+  width: 20vw;
+  height: auto;
+}
 }
 </style>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -8,10 +8,6 @@ const props = defineProps({
     type: Object,
     required: true
   },
-  columnSpan: {
-    type: Number,
-    required: true
-  },
   // eslint-disable-next-line vue/require-default-prop
   selectedImages: Array
 })
@@ -57,7 +53,8 @@ onMounted(() => {
     <v-col
       v-for="image of images"
       :key="image.basename"
-      :cols="columnSpan"
+      class="image-grid-container"
+      :cols="3"
     >
       <v-img
         :src="image.url"
@@ -73,6 +70,9 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.image-grid-container {
+  display: flex;
+}
 .selected-image {
   border: 0.3rem solid var(--dark-green);
 }


### PR DESCRIPTION
## STYLING: Set a fixed size for the image grid

Quick fix: deleted `calculateColumnSpan` and added styling to have a set value for image sizes


https://github.com/LCOGT/datalab-ui/assets/54489472/c3a0e386-c43f-4eec-8550-deca7c8e9819

**Tablet views:**

![1B2FEDF0-3433-4C7C-A7DD-B20778455E7B](https://github.com/LCOGT/datalab-ui/assets/54489472/792fb7ab-403d-4c62-99ef-bb0204a81f2c)


![D3E72B9D-EFF4-4AD0-9F93-C7689501B8CD](https://github.com/LCOGT/datalab-ui/assets/54489472/d71e5d55-1c4e-4585-9cc5-bb4acc0b3f06)

