### PR TITLE
fix for local development content check

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,7 +20,7 @@ async function fetchApiCall({ url, method, body = null, header, successCallback 
   try {
     const response = await fetch(url, config)
     // ok response but empty content
-    if (response.ok && !response.headers.has('content-length')) {
+    if (response.ok && (!response.headers.has('content-length') || response.headers.get('content-length') == 0)) {
       successCallback ? successCallback(null) : null
     } else {
       const responseData = await response.json()


### PR DESCRIPTION
I ran into this while developing with a local instance of the datalab backend.

After some testing there were two behaviors with DELETE. When the frontend hit the delete endpoint on the aws version of the datalab backend content-length does not exist and status-text is blank. However when the frontend hits the delete endpoint on a locally runnning datalab backend it does have content-length = 0. 

To solve this I added another check to the condition of blank content so that deleting will not error when working with a locally hosted version of datalab. 

The cause for the backend sending two different headers for the same operation is unclear however. Could be due to the aws endpoint being https and local being http.

<img width="575" alt="Screenshot 2024-03-08 at 3 01 35 PM" src="https://github.com/LCOGT/datalab-ui/assets/54085254/14a803bb-2f2a-4e16-aa31-9d882940bd32">
