### PR TITLE
Feature/filter by proposal

### DIFF
--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { defineEmits, defineProps } from 'vue'
+import { defineEmits, defineProps, ref } from 'vue'
 import ProjectSelector from './ProjectSelector.vue'
 
-
+const searchQuery = ref('')
 const emit = defineEmits(['selectedProject'])
 
 defineProps({
@@ -24,6 +24,17 @@ const selectProject = (projects) => {
       <p class="project_header">
         PROJECTS
       </p>
+      <v-text-field
+        :model="searchQuery"
+        :loading="loading"
+        append-inner-icon="mdi-magnify"
+        density="compact"
+        label="Search for a project"
+        variant="solo"
+        hide-details
+        single-line
+        class="search_field"
+      />
       <v-expansion-panels
         variant="accordion"
         class="accordion"
@@ -53,6 +64,9 @@ const selectProject = (projects) => {
   text-align: center;
   padding: 2rem;
   color: var(--tan);
+}
+.search_field {
+  background-color: var(--tan)
 }
 @media (max-width: 1200px) {
   .project_bar {

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -7,10 +7,11 @@ const emit = defineEmits(['selectedProject'])
 
 defineProps({
   projects: {
-    type: Object,
+    type: Array,
     required: true
   }
 })
+
 
 const selectProject = (projects) => {
   const proposalId = projects.map(p => p.proposal_id)
@@ -25,8 +26,7 @@ const selectProject = (projects) => {
         PROJECTS
       </p>
       <v-text-field
-        :model="searchQuery"
-        :loading="loading"
+        v-model="searchQuery"
         append-inner-icon="mdi-magnify"
         density="compact"
         label="Search for a project"
@@ -64,9 +64,6 @@ const selectProject = (projects) => {
   text-align: center;
   padding: 2rem;
   color: var(--tan);
-}
-.search_field {
-  background-color: var(--tan)
 }
 @media (max-width: 1200px) {
   .project_bar {

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -1,17 +1,32 @@
 <script setup>
-import { defineEmits, defineProps, ref } from 'vue'
+import { defineEmits, defineProps, ref, computed } from 'vue'
 import ProjectSelector from './ProjectSelector.vue'
 
 const searchQuery = ref('')
 const emit = defineEmits(['selectedProject'])
 
-defineProps({
+const props = defineProps({
   projects: {
-    type: Array,
+    type: Object,
     required: true
   }
 })
 
+
+
+const filteredProjects = computed(() => {
+  if (searchQuery.value) {
+    const filtered = Object.entries(props.projects).reduce((acc, [key, project]) => {
+      if (project[0].proposal_id && project[0].proposal_id.includes(searchQuery.value)) {
+        console.log('yes')
+        acc[key] = project 
+      }
+      return acc
+    }, {})
+    return filtered
+  }
+  return props.projects
+})
 
 const selectProject = (projects) => {
   const proposalId = projects.map(p => p.proposal_id)
@@ -39,12 +54,22 @@ const selectProject = (projects) => {
         variant="accordion"
         class="accordion"
       >
+        <!-- <div v-if="searchQuery.length"> -->
         <ProjectSelector
-          v-for="(project, index) in projects"
+          v-for="(project, index) in filteredProjects"
           :key="index"
           :project="project"
           @click="selectProject(project)"
         />
+        <!-- </div>
+        <div v-else>
+          <ProjectSelector
+            v-for="(project, index) in props.projects"
+            :key="index"
+            :project="project"
+            @click="selectProject(project)"
+          />
+        </div> -->
       </v-expansion-panels>
     </v-card>
   </div>

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -12,6 +12,7 @@ const props = defineProps({
   }
 })
 
+// filtering projects by proposal_id
 const filteredProjects = computed(() => {
   if (searchQuery.value) {
     const filtered = Object.entries(props.projects).reduce((acc, [key, projects]) => {

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -14,10 +14,10 @@ const props = defineProps({
 
 const filteredProjects = computed(() => {
   if (searchQuery.value) {
-    const filtered = Object.entries(props.projects).reduce((acc, [key, project]) => {
-      if (project[0].proposal_id && project[0].proposal_id.includes(searchQuery.value)) {
-        console.log('yes')
-        acc[key] = project 
+    const filtered = Object.entries(props.projects).reduce((acc, [key, projects]) => {
+      const match = projects.some(project => project.proposal_id.toLowerCase().includes(searchQuery.value.toLowerCase()))
+      if (match) {
+        acc[key] = projects
       }
       return acc
     }, {})
@@ -46,28 +46,17 @@ const selectProject = (projects) => {
         variant="solo"
         hide-details
         single-line
-        class="search_field"
       />
       <v-expansion-panels
         variant="accordion"
         class="accordion"
       >
-        <!-- <div v-if="searchQuery.length"> -->
         <ProjectSelector
           v-for="(project, index) in filteredProjects"
           :key="index"
           :project="project"
           @click="selectProject(project)"
         />
-        <!-- </div>
-        <div v-else>
-          <ProjectSelector
-            v-for="(project, index) in props.projects"
-            :key="index"
-            :project="project"
-            @click="selectProject(project)"
-          />
-        </div> -->
       </v-expansion-panels>
     </v-card>
   </div>
@@ -79,6 +68,7 @@ const selectProject = (projects) => {
 }
 .project_card {
   background-color: var(--metal);
+  width: 15vw;
 }
 .project_header { 
   letter-spacing: 0.1rem;

--- a/src/components/Project/ProjectBar.vue
+++ b/src/components/Project/ProjectBar.vue
@@ -12,8 +12,6 @@ const props = defineProps({
   }
 })
 
-
-
 const filteredProjects = computed(() => {
   if (searchQuery.value) {
     const filtered = Object.entries(props.projects).reduce((acc, [key, project]) => {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -169,53 +169,102 @@ onUnmounted(() => {
 <template>
   <!-- only load if config is loaded -->
   <div class="container">
-    <ProjectBar class="project-bar" :projects="projects" @selected-project="filterImagesByProposalId" />
+    <ProjectBar
+      class="project-bar"
+      :projects="projects"
+      @selected-project="filterImagesByProposalId"
+    />
     <div class="image-area h-screen">
-      <div v-if="isLoading" class="loading-indicator-container">
-        <v-progress-circular indeterminate model-value="20" :size="50" :width="9" />
+      <div
+        v-if="isLoading"
+        class="loading-indicator-container"
+      >
+        <v-progress-circular
+          indeterminate
+          model-value="20"
+          :size="50"
+          :width="9"
+        />
       </div>
 
       <div v-else>
-        <ImageCarousel v-if="imageDisplayToggle && selectedProjectImages.length" :data="selectedProjectImages" />
-        <ImageList v-if="!imageDisplayToggle && selectedProjectImages.length" :data="selectedProjectImages" />
+        <ImageCarousel
+          v-if="imageDisplayToggle && selectedProjectImages.length"
+          :data="selectedProjectImages"
+        />
+        <ImageList
+          v-if="!imageDisplayToggle && selectedProjectImages.length"
+          :data="selectedProjectImages"
+        />
         <p v-if="!selectedProjectImages.length">
           Please create a project to use Datalab
         </p>
       </div>
-      <v-skeleton-loader v-if="!store.state.smallImageCache" type="card" />
+      <v-skeleton-loader
+        v-if="!store.state.smallImageCache"
+        type="card"
+      />
       <div class="control-buttons">
-        <v-switch v-model="imageDisplayToggle" class="d-flex mr-4" inset prepend-icon="mdi-view-list"
-          append-icon="mdi-image" />
-        <v-btn :disabled="noSelectedImages" class="add_button" @click="getDataSessions">
+        <v-switch
+          v-model="imageDisplayToggle"
+          class="d-flex mr-4"
+          inset
+          prepend-icon="mdi-view-list"
+          append-icon="mdi-image"
+        />
+        <v-btn
+          :disabled="noSelectedImages"
+          class="add_button"
+          @click="getDataSessions"
+        >
           Add to a Session
         </v-btn>
       </div>
     </div>
   </div>
-  <v-dialog v-model="isPopupVisible" width="300">
+  <v-dialog
+    v-model="isPopupVisible"
+    width="300"
+  >
     <v-card class="card">
       <v-card-title class="sessions_header">
         DATA SESSIONS
       </v-card-title>
       <v-card-text>
         <v-list>
-          <v-list-item v-for="session in uniqueDataSessions" :key="session.id" class="sessions"
-            @click="selectDataSession(session)">
+          <v-list-item
+            v-for="session in uniqueDataSessions"
+            :key="session.id"
+            class="sessions"
+            @click="selectDataSession(session)"
+          >
             {{ session.name }}
           </v-list-item>
         </v-list>
         <!-- Input for new session name -->
-        <v-text-field v-model="newSessionName" label="New Session Name" class="sessions" />
+        <v-text-field
+          v-model="newSessionName"
+          label="New Session Name"
+          class="sessions"
+        />
         <!-- Error message -->
         <div v-if="errorMessage">
           {{ errorMessage }}
         </div>
       </v-card-text>
       <v-card-actions>
-        <v-btn text class="button create_button" @click="createNewDataSession">
+        <v-btn
+          text
+          class="button create_button"
+          @click="createNewDataSession"
+        >
           Create New Session
         </v-btn>
-        <v-btn text class="button cancel_button" @click="isPopupVisible = false">
+        <v-btn
+          text
+          class="button cancel_button"
+          @click="isPopupVisible = false"
+        >
           Close
         </v-btn>
       </v-card-actions>


### PR DESCRIPTION
## FEATURE: Filter by proposal id 
**Background:**
In the future, the kids will probably have dozens (maybe hundreds?) of proposals/projects. I added logic to be able to filter by `proposal_id` so that the kids can easily search for their projects

**Implementation:**
First, I added a ref called `searchQuery` that checks for the user's input in the new `v-text-field`. 
Then, I defined a computed property called `filteredProjects` to filter projects based on the search query.
I first reduce to accumulate projects that match the `proposal_id` based on the `searchQuery`. If any projects match, add  them to the accumulator and then return the acc for the next iteration. 
Lastly, return the filtered list of projects.
If nothing is found, then just return all of the projects

### VISUALS
**Screen recording of successful filtering and everything still working as usual**


https://github.com/LCOGT/datalab-ui/assets/54489472/2a7ccfc1-f636-44da-9bc4-dc391c43fc24





