### PR TITLE
Feature/add image counter

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -69,7 +69,7 @@ const noSelectedImages = computed(() => {
   return store.getters.selectedImages.length === 0
 })
 
-const displayImageCounter = computed(() => {
+const imageCounter = computed(() => {
   return store.state.selectedImages.length
 })
 
@@ -220,11 +220,11 @@ onUnmounted(() => {
           class="add_button"
           @click="getDataSessions"
         >
-          <template v-if="displayImageCounter === 0">
+          <template v-if="imageCounter === 0">
             Select images
           </template>
           <template v-else>
-            Add {{ displayImageCounter }} image<span v-if="displayImageCounter > 1">s</span>
+            Add {{ imageCounter }} image<span v-if="imageCounter > 1">s</span>
           </template>
         </v-btn>
       </div>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -69,6 +69,10 @@ const noSelectedImages = computed(() => {
   return store.getters.selectedImages.length === 0
 })
 
+const displayImageCounter = computed(() => {
+  return store.state.selectedImages.length
+})
+
 // manages successful api response by mapping data to unique sessions
 const mapDataSessions = (data) => {
   const results = data.results
@@ -216,7 +220,12 @@ onUnmounted(() => {
           class="add_button"
           @click="getDataSessions"
         >
-          Add to a Session
+          <template v-if="displayImageCounter === 0">
+            Select images
+          </template>
+          <template v-else>
+            Add {{ displayImageCounter }} image<span v-if="displayImageCounter > 1">s</span>
+          </template>
         </v-btn>
       </div>
     </div>


### PR DESCRIPTION
## FEATURE: Add image counter to Project View
**Background:**
To make the user experience a much smoother one, I added an image counter to the 'add to data session' button that now has a different text 

**Implementation:**
Added a computed property that returns the length of selected images. And some conditional rendering depending on the `selectedImages` length. You can see in the video below the result. Constructive feedback on what the text should read is welcomed.


https://github.com/LCOGT/datalab-ui/assets/54489472/ef30b920-748e-48ff-a6cf-a1a0fb42982c



