### PR TITLE
added logic to close popup and give newsessionname value ''

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -146,6 +146,11 @@ const validateSessionName = () => {
   }
 }
 
+const closePopup = () => {
+  isPopupVisible.value = false
+  newSessionName.value = ''
+}
+
 // handles creation of a new session 
 const createNewDataSession = async () => {
   const selectedImages = store.state.selectedImages
@@ -291,7 +296,7 @@ onUnmounted(() => {
           <v-btn
             text 
             class="cancel_button" 
-            @click="isPopupVisible = false"
+            @click="closePopup"
           >
             Close
           </v-btn>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -149,6 +149,7 @@ const validateSessionName = () => {
 const closePopup = () => {
   isPopupVisible.value = false
   newSessionName.value = ''
+  errorMessage.value = ''
 }
 
 // handles creation of a new session 


### PR DESCRIPTION
## CHORE: Close pop up and remove new session name on cancel 

**Background:**
More QOL chores. This one removes the session name that the user had written if they select cancel.

**Implementation:**
```
const closePopup = () => {
  isPopupVisible.value = false
  newSessionName.value = ''
  errorMessage.value = ''
}
```

that's all :) 

**EDIT: HERE'S THE CORRECT VIDEO**


https://github.com/LCOGT/datalab-ui/assets/54489472/26814270-e0ec-45b1-84cb-8254e70f9d97


