### PR TITLE
Global Alerts, Handling of failed operations, Wizard Styling changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@ import { onMounted, computed, watch } from 'vue'
 import { useUserDataStore } from '@/stores/userData'
 import { useConfigurationStore } from './stores/configuration'
 import NavBar from './components/Global/NavBar.vue'
+import AlertToast from './components/Global/AlertToast.vue'
 
 const configurationStore = useConfigurationStore()
 const userDataStore = useUserDataStore()
@@ -39,6 +40,7 @@ watch(() => userDataStore.isColorblindMode, (newVal) => {
   <template v-if="loadedConfig">
     <template v-if="userDataStore.userIsAuthenticated">
       <nav-bar />
+      <alert-toast />
     </template>
     <router-view />
   </template>

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -114,6 +114,7 @@ function goForward() {
       operationDefinition.input_data[inputKey] = selected
     }
     emit('addOperation', operationDefinition)
+    emit('closeWizard')
   }
 }
 
@@ -189,7 +190,6 @@ function selectImage(inputKey, imageIndex) {
           />
           <div
             v-else-if="inputDescription.type == 'file'"
-            class="images-container"
           >
             <div
               v-if="inputDescription.name"
@@ -276,23 +276,10 @@ function selectImage(inputKey, imageIndex) {
 }
 
 .operation-input {
-  width: 10vw;
-  margin-left: 2%;
-  background-color: var(--metal);
-  position: fixed;
-  top: 6%;
+  margin-top: 2rem;
+  width: 12rem;
 }
 
-.images-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  flex-direction: column;
-  width: 100%;
-  padding-left: 2rem;
-  padding-right: 2rem;
-  margin-top: 6%;
-}
 .input-images {
   font-family: 'Open Sans', sans-serif;
   color: var(--tan);
@@ -324,34 +311,5 @@ function selectImage(inputKey, imageIndex) {
 .gofwd-btn {
   color: var(--light-blue);
   font-size: 1.2rem;
-}
-
-@media (max-width: 1200px) {
-  .operation-input {
-    margin-left: 3%;
-  }
-
-  .images-container {
-    margin-top: 2%;
-  }
-}
-
-@media (max-width: 900px) {
-  .selected-operation {
-    height: 120%;
-  }
-
-  .operation-description {
-    font-size: 1rem;
-  }
-
-  .operation-input {
-    margin-left: 4%;
-    width: 15vw;
-  }
-
-  .images-container {
-    margin-top: 3%;
-  }
 }
 </style>

--- a/src/components/Global/AlertToast.vue
+++ b/src/components/Global/AlertToast.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { useAlertsStore } from '../../stores/alerts'
+
+const alertStore = useAlertsStore()
+const showAlert = ref(false)
+
+watch(() => alertStore.alertText, () => {showAlert.value = true})
+
+</script>
+<template>
+  <v-fade-transition>
+    <v-alert
+      v-model="showAlert"
+      closable
+      :type="alertStore.alertType"
+      :text="alertStore.alertText"
+    />
+  </v-fade-transition>
+</template>
+<style scoped>
+  .v-alert {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
+    padding: 10px;
+    margin: 2rem;
+  }
+</style>

--- a/src/stores/alerts.js
+++ b/src/stores/alerts.js
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+
+/**
+ * This store is used to manage the alert that is displayed at the top of the page.
+ * The alert can be of type 'success', 'error', 'warning', or 'info'.
+ * To use this import the store and call the setAlert action with the type and text of the alert.
+ */
+export const useAlertsStore = defineStore('alerts', {
+  state() {
+    return{
+      // The type of alert to display ('success', 'error', 'warning', 'info')
+      alertType: 'warning',
+      // The text to display in the alert
+      alertText: 'default alert text',
+    }
+  },
+  actions: {
+    setAlert(type, text, prefix = '') {
+      console.log('prefix', prefix)
+      console.log(prefix + text)
+      this.alertType = type
+      this.alertText = prefix ? prefix + ' ' + text : text
+    }
+  }
+})

--- a/src/stores/alerts.js
+++ b/src/stores/alerts.js
@@ -16,8 +16,6 @@ export const useAlertsStore = defineStore('alerts', {
   },
   actions: {
     setAlert(type, text, prefix = '') {
-      console.log('prefix', prefix)
-      console.log(prefix + text)
       this.alertType = type
       this.alertText = prefix ? prefix + ' ' + text : text
     }

--- a/src/utils/imageLoader.js
+++ b/src/utils/imageLoader.js
@@ -26,7 +26,6 @@ async function getImageFromBasename(size, archive, url, imageBasename) {
 }
 
 async function deleteCachedImageFromBasename(size, imageBasename) {
-  console.log('Calling deleteCachedImageFromBasename with basename: ' + size + ' - ' + imageBasename)
   const cacheName = size + 'Thumbnails'
   return caches.open(cacheName).then((cache) => {
     return cache.delete(imageBasename, cacheOptions)
@@ -43,7 +42,6 @@ async function cacheImageFromUrl(size, url, imageBasename) {
 }
 
 async function cacheImageFromBasename(size, archive, url, imageBasename) {
-  console.log('Calling cacheImageFromBasename with basename: ' + size + ' - ' + imageBasename)
   // Right now we only have a ptr archive, but planning to maybe use this to differentiate later
   // If url exists, it will use that to directly download and cache image. If not it will use
   // the archive to decide how to fetch the image based on its basename and archive.

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -29,7 +29,7 @@ onMounted(async () => {
     tab.value = firstSessionId
     settingsStore.recentSessionId = firstSessionId
   } else {
-    console.log('no data sessions available to display')
+    console.error('no data sessions available to display')
   }
 })
 


### PR DESCRIPTION
Added a global alert component that shows a small toast at the bottom of the page. Added a store called `alerts` the alert toast listens to so if any component wants to be able to create alerts they just need to import the store and call it's `setAlert` function.

OperationPipeline polling status now has a check for `FAILED` operations. When an operation fails a couple things happen:
1. An Alert toast is shown with the error
2. We emit a `deleteSession` event to the parent `DataSessions`
3. The parent sends a delete api call to the backend to remove the failed operation and then reloads to update

Other Small things
- Noticed a lot of code reuse when clearing the polling data so bundled it all up into one function called `clearPolling(operationID)`
- Changed the way that the selected button is highlighted to use a vue3 class binding to remove the need for an extra function at the top of the file
- Moved the operation wizard from inside the operation pipeline as it didn't have any need to be a level down and was just passing the images prop through the pipeline. Now instead of `DataSessions` -> `OperationPipeline` -> `OperationWizard` it is `OperationWizard`  <- `DataSessions` -> `OperationPipeline` for better hierarchy. 
- Had to delete some of the css in the wizard since it was overflowing and the input boxes were unable to be seen when there was more than one. 


https://github.com/LCOGT/datalab-ui/assets/54085254/a826c846-ff99-4fe1-9a22-1495f95c5bcb

