### PR TITLE
Feature/rgb composite

### DIFF
--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -93,6 +93,13 @@ const wizardTitle = computed(() => {
 
 function goForward() {
   if (page.value == 'select') {
+    // if there are no images for a filter required by the operation, do not proceed
+    for (const inputKey in selectedOperationInputs.value) {
+      const inputField = selectedOperationInputs.value[inputKey]
+      if (inputField.type == 'file' && imagesWithFilter(inputField.filter).length == 0){
+        return
+      }
+    }
     page.value = 'configure'
   }
   else {

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -91,14 +91,6 @@ const wizardTitle = computed(() => {
   }
 })
 
-function imagesWithFilter(filters) {
-  const imagesFiltered = props.images.filter((image) => filters.includes(image.filter))
-  if (imagesFiltered.length == 0) {
-    alert.setAlert('warning', 'Operation requires images with filter ' + filters.join(', '))
-  }
-  return imagesFiltered
-}
-
 function goForward() {
   if (page.value == 'select') {
     page.value = 'configure'
@@ -111,15 +103,27 @@ function goForward() {
       }
     }
     for (const inputKey in selectedImages.value) {
-      let selected = []
+      let input = []
+      const filter = selectedOperationInputs.value[inputKey].filter
       selectedImages.value[inputKey].forEach(index => {
-        selected.push(props.images[index])
+        input.push(imagesWithFilter(filter)[index])
       })
-      operationDefinition.input_data[inputKey] = selected
+      operationDefinition.input_data[inputKey] = input
     }
     emit('addOperation', operationDefinition)
     emit('closeWizard')
   }
+}
+
+function imagesWithFilter(filters) {
+  if(!filters) {
+    return props.images
+  }
+  const imagesFiltered = props.images.filter((image) => filters.includes(image.filter))
+  if (imagesFiltered.length == 0) {
+    alert.setAlert('warning', 'Operation requires images with filter ' + filters.join(', '))
+  }
+  return imagesFiltered
 }
 
 function selectImage(inputKey, imageIndex) {
@@ -209,7 +213,7 @@ function selectImage(inputKey, imageIndex) {
               {{ inputDescription.name }}
             </div>
             <image-grid
-              :images="inputDescription.filter ? imagesWithFilter(inputDescription.filter) : images"
+              :images="imagesWithFilter(inputDescription.filter)"
               :selected-images="selectedImages[inputKey]"
               :column-span="calculateColumnSpan(images.length, imagesPerRow)"
               class="wizard-images"

--- a/src/components/Global/AlertToast.vue
+++ b/src/components/Global/AlertToast.vue
@@ -23,7 +23,8 @@ watch(() => alertStore.alertText, () => {showAlert.value = true})
     position: absolute;
     bottom: 0;
     left: 0;
-    z-index: 9999;
+    /* to show above the v-overlay whose z-index is 2400 */
+    z-index: 2401;
     padding: 10px;
     margin: 2rem;
   }

--- a/src/components/Global/AlertToast.vue
+++ b/src/components/Global/AlertToast.vue
@@ -23,7 +23,7 @@ watch(() => alertStore.alertText, () => {showAlert.value = true})
     position: absolute;
     bottom: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 9999;
     padding: 10px;
     margin: 2rem;
   }

--- a/src/components/Global/FilterBadge.vue
+++ b/src/components/Global/FilterBadge.vue
@@ -33,5 +33,6 @@ const badgeColor = computed(() => {
   border-radius: 5px;
   color: var(--tan);
   padding: 5px 10px;
+  display: inline-block;
 }
 </style>

--- a/src/components/Global/FilterBadge.vue
+++ b/src/components/Global/FilterBadge.vue
@@ -9,7 +9,7 @@ const props = defineProps({
 
 const badgeColor = computed(() => {
   switch (props.filter) {
-  case 'R': case 'rp': case 'w':
+  case 'R': case 'rp':
     return 'red'
   case 'V': case 'gp':
     return 'green'

--- a/src/components/Global/FilterBadge.vue
+++ b/src/components/Global/FilterBadge.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from 'vue'
+const props = defineProps({
+  filter: {
+    type: String,
+    required: true
+  }
+})
+
+const badgeColor = computed(() => {
+  switch (props.filter) {
+  case 'R': case 'rp': case 'w':
+    return 'red'
+  case 'V': case 'gp':
+    return 'green'
+  case 'B':
+    return 'blue'
+  default:
+    return 'var(--metal)'
+  }
+})
+</script>
+<template>
+  <p
+    class="filter-badge"
+    :style="{ backgroundColor: badgeColor}"
+  >
+    {{ props.filter }}
+  </p>
+</template>
+<style scoped>
+.filter-badge {
+  border-radius: 5px;
+  color: var(--tan);
+  padding: 5px 10px;
+}
+</style>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -64,15 +64,15 @@ watch(() => props.images, () => {
         aspect-ratio="1"
         @click="emit('selectImage', index)"
       >
+        <filter-badge
+          v-if="image.filter"
+          :filter="image.filter"
+        />
         <span
           v-if="'operationIndex' in image"
           class="image-text-overlay"
         >{{ image.operationIndex }}</span>
       </v-img>
-      <filter-badge
-        v-if="image.filter"
-        :filter="image.filter"
-      />
     </v-col>
   </v-row>
 </template>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { defineProps, ref, defineEmits, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useConfigurationStore } from '@/stores/configuration'
 import FilterBadge from './FilterBadge.vue'
@@ -8,6 +8,10 @@ const props = defineProps({
   images: {
     type: Array,
     required: true
+  },
+  selectedImages: {
+    type: Array,
+    default: () => []
   },
   columnSpan: {
     type: Number,
@@ -20,30 +24,16 @@ const props = defineProps({
 })
 
 let imageDetails = ref({})
-let selectedImages = ref([])
 const configurationStore = useConfigurationStore()
 const thumbnailsStore = useThumbnailsStore()
 const emit = defineEmits(['selectImage'])
 
 
 const isSelected = (index) => {
-  return selectedImages.value.includes(index)
-}
-
-const onImageClick = (index) => {
-  if (props.allowSelection) {
-    if (selectedImages.value.includes(index)) {
-      selectedImages.value.splice(selectedImages.value.indexOf(index), 1)
-    }
-    else {
-      selectedImages.value.push(index)
-    }
-    emit('selectImage', index)
-  }
+  return props.selectedImages.includes(index)
 }
 
 watch(() => props.images, () => {
-  selectedImages.value = []
   props.images.forEach(image => {
     if (image.basename && !(image.basename in imageDetails.value)) {
       imageDetails.value[image.basename] = ref('')
@@ -72,7 +62,7 @@ watch(() => props.images, () => {
         cover
         :class="{ 'selected-image': isSelected(index) }"
         aspect-ratio="1"
-        @click="onImageClick(index)"
+        @click="emit('selectImage', index)"
       >
         <span
           v-if="'operationIndex' in image"
@@ -99,6 +89,6 @@ watch(() => props.images, () => {
   float: right;
 }
 .image-grid-col {
-  max-width: 300px;
+  max-width: 200px;
 }
 </style>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -2,6 +2,7 @@
 import { defineProps, ref, defineEmits, watch } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useConfigurationStore } from '@/stores/configuration'
+import FilterBadge from './FilterBadge.vue'
 
 const props = defineProps({
   images: {
@@ -62,6 +63,7 @@ watch(() => props.images, () => {
       v-for="(image, index) in props.images"
       :key="index"
       :cols="columnSpan"
+      class="image-grid-col"
     >
       <v-img
         v-if="image.basename in imageDetails && imageDetails[image.basename]"
@@ -70,7 +72,6 @@ watch(() => props.images, () => {
         cover
         :class="{ 'selected-image': isSelected(index) }"
         aspect-ratio="1"
-        class="image-grid"
         @click="onImageClick(index)"
       >
         <span
@@ -78,6 +79,10 @@ watch(() => props.images, () => {
           class="image-text-overlay"
         >{{ image.operationIndex }}</span>
       </v-img>
+      <filter-badge
+        v-if="image.filter"
+        :filter="image.filter"
+      />
     </v-col>
   </v-row>
 </template>
@@ -93,12 +98,7 @@ watch(() => props.images, () => {
   margin-right: 5px;
   float: right;
 }
-.image-grid {
-  max-width: 200px;
-}
-@media (max-width: 900px) {
-.image-grid {
-  width: 20vw;
-}
+.image-grid-col {
+  max-width: 300px;
 }
 </style>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -83,29 +83,22 @@ watch(() => props.images, () => {
 </template>
 
 <style scoped>
-.image-grid-container {
-  display: flex;
-  max-width: 200px;
-  max-height: 200px;
-}
 .selected-image {
   border: 0.3rem solid var(--dark-green);
 }
 
 .image-text-overlay {
-  color: white;
+  color: var(--tan);
   font-weight: bold;
   margin-right: 5px;
   float: right;
 }
 .image-grid {
   max-width: 200px;
-  height: auto;
 }
 @media (max-width: 900px) {
 .image-grid {
   width: 20vw;
-  height: auto;
 }
 }
 </style>

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -69,9 +69,7 @@ function handleAnalysisOutput(response, action){
           :download="image.basename"
           target="_blank"
         >
-          <v-btn
-            icon="mdi-download"
-          />
+          <v-icon icon="mdi-download" />
         </a>
         <v-btn
           icon="mdi-close"
@@ -92,6 +90,7 @@ function handleAnalysisOutput(response, action){
             <p>Site: {{ image.site_id }}</p>
             <p>Telescope: {{ image.telescope_id }}</p>
             <p>Instrument: {{ image.instrument_id }}</p>
+            <p>Filter: {{ image.FILTER }}</p>
           </v-sheet>
           <line-plot
             :y-axis-luminosity="lineProfile"
@@ -105,6 +104,9 @@ function handleAnalysisOutput(response, action){
   </v-dialog>
 </template>
 <style scoped>
+a{
+  color: var(--tan);
+}
 .analysis-sheet{
   background-color: var(--dark-blue);
   font-family: 'Open Sans', sans-serif;

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -4,6 +4,7 @@ import { fetchApiCall } from '../../../utils/api'
 import { useConfigurationStore } from '@/stores/configuration'
 import ImageViewer from './ImageViewer.vue'
 import LinePlot from './LinePlot.vue'
+import FilterBadge from '@/components/Global/FilterBadge.vue'
 
 // eslint-disable-next-line no-unused-vars
 const props = defineProps(['modelValue', 'image'])
@@ -90,7 +91,12 @@ function handleAnalysisOutput(response, action){
             <p>Site: {{ image.site_id }}</p>
             <p>Telescope: {{ image.telescope_id }}</p>
             <p>Instrument: {{ image.instrument_id }}</p>
-            <p>Filter: {{ image.FILTER }}</p>
+            <span>Filter: 
+              <filter-badge
+                v-if="image.FILTER"
+                :filter="image.FILTER"
+              />
+            </span>
           </v-sheet>
           <line-plot
             :y-axis-luminosity="lineProfile"

--- a/src/components/Project/ImageCarousel.vue
+++ b/src/components/Project/ImageCarousel.vue
@@ -7,6 +7,7 @@ import { useThumbnailsStore } from '@/stores/thumbnails'
 import { Carousel, Slide } from 'vue3-carousel'
 import 'vue3-carousel/dist/carousel.css'
 import ImageAnalyzer from './ImageAnalysis/ImageAnalyzer.vue'
+import FilterBadge from '@/components/Global/FilterBadge.vue'
 
 const props = defineProps({
   data: {
@@ -109,14 +110,21 @@ watch(() => props.data, (newVal) => {
     </Slide>
   </Carousel>
   <Carousel
-    class="mt-4"
     id="thumbnails"
+    ref="carousel"
+    v-model="currentSlide"
+    class="mt-4"
     :wrap-around="false"
     :breakpoints="breakpoints"
-    v-model="currentSlide"
-    ref="carousel">
-    <Slide v-for="(item, index) in data" :key="index">
-      <div class="carousel__item" @click="handleThumbnailClick(item, index)">
+  >
+    <Slide
+      v-for="(item, index) in data"
+      :key="index"
+    >
+      <div
+        class="carousel__item"
+        @click="handleThumbnailClick(item, index)"
+      >
         <v-img
           :src="item.smallCachedUrl"
           loading="lazy"
@@ -124,7 +132,12 @@ watch(() => props.data, (newVal) => {
           class="thumbnail__item"
           :class="{'selected-thumbnail': store.isSelected(item)}"
           :alt="item.OBJECT"
-        />
+        >
+          <filter-badge
+            v-if="item.FILTER"
+            :filter="item.FILTER"
+          />
+        </v-img>
       </div>
     </Slide>
   </Carousel>

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -11,7 +11,7 @@ const props = defineProps(['data'])
 let headers = ref([
   { title: 'IMAGE NAME', align: 'start', sortable: true, key: 'basename' },
   { title: 'TIME', align: 'start', sortable: true, key: 'observation_date' },
-  { title: 'OBJECT', align: 'start', sortable: true, key: 'OBJECT' },
+  { title: 'FILTER', align: 'start', sortable: true, key: 'FILTER' },
   { title: 'IMAGE', align: 'start', sortable: false, key: 'url' },
 ])
 let itemsPerPage = ref(15)
@@ -64,6 +64,8 @@ onMounted ( () => {
   color: var(--tan);
   font-size: 1.4rem;
   background-color: var(--metal);
+  overflow-y: scroll;
+  max-height: 80vh;
 }
 .list_image{
   height: 8vh;

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -2,6 +2,7 @@
 <script setup>
 import { ref, onMounted, defineProps } from 'vue'
 import { useSettingsStore } from '@/stores/settings'
+import FilterBadge from '@/components/Global/FilterBadge.vue'
 
 const store = useSettingsStore()
 // eslint-disable-next-line no-unused-vars
@@ -38,11 +39,16 @@ onMounted ( () => {
     item-value="basename"
     :return-object="true"
     show-select
-    density="compact"
     :hover="true"
     class="data_table"
     @update:model-value="select($event)"
   >
+    <template #[`item.FILTER`]="{ item }">
+      <filter-badge
+        v-if="item.FILTER"
+        :filter="item.FILTER"
+      />
+    </template>
     <template #[`item.url`]="{ item }">
       <v-img
         :src="item.smallCachedUrl"

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -25,7 +25,7 @@ onBeforeMount(() => {
   if (!userDataStore.userIsAuthenticated) router.push({ name: 'Registration' })
 })
 
-const selectedProjectImages = ref([])
+const proposalImages = ref([])
 
 // handles the selected project to filter images that only have the selected proposal_id
 async function filterImagesByProposalId(proposalId) {
@@ -36,7 +36,7 @@ async function filterImagesByProposalId(proposalId) {
     await settingsStore.loadAndCacheImages(proposalId, 'reduction_level=91')
   }
   isLoading.value = false
-  selectedProjectImages.value = settingsStore.imagesByProposal[proposalId]
+  proposalImages.value = settingsStore.imagesByProposal[proposalId]
 }
 
 // boolean computed property used to disable the add to session button
@@ -129,27 +129,27 @@ const closePopup = () => {
 
 // handles creation of a new session 
 const createNewDataSession = async () => {
-  const selectedImages = settingsStore.selectedImages
-  const inputData = selectedImages.map(image => ({
+  // Add more fields from the archive image here if needed
+  const inputData = settingsStore.selectedImages.map(image => ({
     'source': 'archive',
-    'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
+    'basename': image.basename.replace('-small', '') || image.basename.replace('-large', ''),
+    'filter': image.FILTER
   }))
   const requestBody = {
     'name': newSessionName.value,
     'input_data': inputData
   }
 
-  // attempting a POST request for new session
-  const response = await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody })
-  if (response) {
+  const onCreateSuccess = (response)=> {
     isPopupVisible.value = false
     newSessionName.value = ''
     errorMessage.value = ''
     settingsStore.recentSessionId = response.id
     router.push({ name: 'DataSessionView' })
-  } else {
-    errorMessage.value = 'Error creating new data session'
   }
+
+  // attempting a POST request for new session
+  await fetchApiCall({ url: dataSessionsUrl, method: 'POST', body: requestBody, successCallback: onCreateSuccess, failCallback: handleError})
 }
 
 const sessionNameExists = (name) => {
@@ -197,15 +197,15 @@ onUnmounted(() => {
       </div>
       <div v-else>
         <ImageCarousel
-          v-if="userDataStore.carouselGridToggle && selectedProjectImages.length"
-          :data="selectedProjectImages"
+          v-if="userDataStore.carouselGridToggle && proposalImages.length"
+          :data="proposalImages"
         />
         <ImageList
-          v-if="!userDataStore.carouselGridToggle && selectedProjectImages.length"
-          :data="selectedProjectImages"
+          v-if="!userDataStore.carouselGridToggle && proposalImages.length"
+          :data="proposalImages"
         />
         <v-banner
-          v-if="!selectedProjectImages.length"
+          v-if="!proposalImages.length"
           class="d-flex align-center justify-center mt-10"
           icon="mdi-image-off"
           color="warning"

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -84,7 +84,8 @@ const addImagesToExistingSession = async (session) => {
     const selectedImages = settingsStore.selectedImages
     const inputData = [...currentSessionData, ...selectedImages.map(image => ({
       'source': 'archive',
-      'basename': image.basename.replace('-small', '') || image.basename.replace('-large', '')
+      'basename': image.basename.replace('-small', '') || image.basename.replace('-large', ''),
+      'filter': image.FILTER
     }))]
     const requestBody = {
       'name': session.name,


### PR DESCRIPTION
Lots of changes to support the RGB operation. Adds the `filter` component that lets users know what filters an image has. 
Implement the filtering for inputs to set their max and min selected images as well as what filters are required for inputs. 
The general idea is that users will be able to know what filters their images have and easily be able to create RGB operations while being constrained to entering only valid input. 

Other changes 
- Added `alerts` to operation wizard so when max and min inputs are failed the user knows
- `imagesWithFilter` function helps display only R,G,B images if an input requests for it
- add check for max images in an input
- `image-grid` prop `selected-images` is now tracked by the parent and passed to `image-grid` this is so the parent can have better control over what images show up as selected since they are the one implementing logic to decide what to do with the selected images
- `alert-toast` `z-index` set to `9999` so it can show over the `v-dialog` which has a `z-index: 2400`
- new `FilterBadge` component that decides what color to be depending on the filter name passed to it. When we add more supported colored filters in the future this should be updated
- `FilterBadge` is added to `imageCarousel` ,`imageList`, `imageAnalysis`, and `imageGrid` as these are all places users would be interested to know the filter type of the image
- fix download button not being the same color as the rest of the analysis page
- list view now fits screen and scrolls for a much nicer behavior
- add `filter` to image objects

<img width="573" alt="Screenshot 2024-07-30 at 12 09 12 PM" src="https://github.com/user-attachments/assets/b7244dea-7c47-4ef4-98a2-e37cea94992a">
<img width="1183" alt="Screenshot 2024-07-30 at 12 09 00 PM" src="https://github.com/user-attachments/assets/1e24d117-5fcb-47a6-b1a8-457f1b08e854">
<img width="1400" alt="Screenshot 2024-07-30 at 12 08 52 PM" src="https://github.com/user-attachments/assets/8cb9ef69-19d2-414f-b684-ec09e506072d">
<img width="1457" alt="Screenshot 2024-07-30 at 12 08 32 PM" src="https://github.com/user-attachments/assets/5adb94d5-0156-4960-aec5-c6156ff7c093">
<img width="1715" alt="Screenshot 2024-07-30 at 12 08 18 PM" src="https://github.com/user-attachments/assets/60cd9bd9-e4d3-4a0b-b1c2-4fe62d6e10f7">

