### PR TITLE
Add support for thumbnails in the archive

### DIFF
--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -37,7 +37,7 @@ watch(() => props.images, () => {
   props.images.forEach(image => {
     if (image.basename && !(image.basename in imageDetails.value)) {
       imageDetails.value[image.basename] = ref('')
-      const url = image.thumbnail_url || ''
+      const url = image.thumbnail_url || image.smallThumbUrl || ''
       thumbnailsStore.cacheImage('small', configurationStore.archiveType, url, image.basename).then((cachedUrl) => {
         imageDetails.value[image.basename] = cachedUrl
       })

--- a/src/components/Project/ImageCarousel.vue
+++ b/src/components/Project/ImageCarousel.vue
@@ -66,7 +66,7 @@ const handleThumbnailClick = (item, index) => {
 watch(currLargeImage, async (newValue) => {
   if (newValue){
     currLargeImage.value.largeCachedUrl = ref('')
-    thumbnailsStore.cacheImage('large', configurationStore.archiveType, '', newValue.basename).then((cachedUrl) => {
+    thumbnailsStore.cacheImage('large', configurationStore.archiveType, newValue.largeThumbUrl, newValue.basename).then((cachedUrl) => {
       currLargeImage.value.largeCachedUrl = cachedUrl
     })
   }

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -35,13 +35,24 @@ export const useSettingsStore = defineStore('settings', {
       const timeStr = `start=${this.startDate.toISOString()}&end=${this.endDate.toISOString()}`
       option = option ? `${option}&${timeStr}` : timeStr
       option += '&proposal_id=' + proposal
+      option += '&include_thumbnails=true'
       const imageUrl = option ? `${baseUrl}?${option}` : baseUrl
       const responseData = await fetchApiCall({ url: imageUrl, method: 'GET' })
       if (responseData && responseData.results) {
         // Preload all the small thumbnails into the cache. The large thumbnails will be loaded on demand
         responseData.results.forEach((frame) => {
+          frame.smallThumbUrl = ''
+          frame.largeThumbUrl = ''
+          for (const thumbnail of frame.thumbnails) {
+            if (thumbnail.size === 'small') {
+              frame.smallThumbUrl = thumbnail.url
+            }
+            else if (thumbnail.size === 'large') {
+              frame.largeThumbUrl = thumbnail.url
+            }
+          }
           frame.smallCachedUrl = ref('')
-          thumbnailsStore.cacheImage('small', configurationStore.archiveType, '', frame.basename).then((cachedUrl) => {
+          thumbnailsStore.cacheImage('small', configurationStore.archiveType, frame.smallThumbUrl, frame.basename).then((cachedUrl) => {
             frame.smallCachedUrl.value = cachedUrl
           })
         })


### PR DESCRIPTION
Add a `smallThumbUrl` and `largeThumbUrl` to the archive image results - either empty if there are no thumbnails in the response, or the thumb url if it exists. Then use that throughout when caching them. The caching code already pulls either directly from a URL or from the thumbservice so if a URL is provided it will use that.

To actually test this, you have to set the reduction level to 0 for archive images you retrieve since we only have the thumbnails for raw images that are EXPOSE type... 