### PR TITLE
Shows the source catalog when loaded, Source catalog markers can't be edited

### DIFF
--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -7,7 +7,17 @@ import LinePlot from './LinePlot.vue'
 import FilterBadge from '@/components/Global/FilterBadge.vue'
 import ImageDownloadMenu from '@/components/Project/ImageAnalysis/ImageDownloadMenu.vue'
 
-const props = defineProps(['modelValue', 'image'])
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    required: true,
+  },
+  image: {
+    type: Object,
+    required: true,
+    default: null,
+  }
+})
 const emit = defineEmits(['update:modelValue'])
 const configStore = useConfigurationStore()
 

--- a/src/components/Project/ImageAnalysis/ImageViewer.vue
+++ b/src/components/Project/ImageAnalysis/ImageViewer.vue
@@ -221,7 +221,7 @@ function createCatalogLayer(){
       fillColor: 'var(--tangerine)',
       fillOpacity: 0.2,
       radius: 10,
-      pmIgnore: true
+      pmIgnore: true // Ignore this layer for geoman editing
     })
 
     sourceMarker.bindPopup(`Flux: ${source.flux}<br>Ra: ${source.ra}<br>Dec: ${source.dec}`)

--- a/src/components/Project/ImageAnalysis/ImageViewer.vue
+++ b/src/components/Project/ImageAnalysis/ImageViewer.vue
@@ -191,6 +191,7 @@ function handleEdit(event) {
   requestLineProfile(event.layer.getLatLngs())
 }
 
+// Event handler for drawn lines, emits an action that will trigger an api call in the parent
 function requestLineProfile(latLngs) {
   // Check that there are two points to calculate the line length
   if (latLngs.length < 2) return
@@ -208,6 +209,7 @@ function requestLineProfile(latLngs) {
   emit('analysisAction', 'line-profile', lineProfileInput)
 }
 
+// When we get the catalog data this creates a layer of circles on the map
 function createCatalogLayer(){
   if (!props.catalog) return
 
@@ -218,7 +220,8 @@ function createCatalogLayer(){
       color: 'var(--tangerine)',
       fillColor: 'var(--tangerine)',
       fillOpacity: 0.2,
-      radius: 10
+      radius: 10,
+      pmIgnore: true
     })
 
     sourceMarker.bindPopup(`Flux: ${source.flux}<br>Ra: ${source.ra}<br>Dec: ${source.dec}`)
@@ -226,6 +229,10 @@ function createCatalogLayer(){
   })
 
   let catalogLayerGroup = L.layerGroup(catalogMarkers)
+
+  // Shows the catalog layer by default
+  catalogLayerGroup.addTo(image)
+
   layerControl.addOverlay(catalogLayerGroup, 'Source Catalog')
 }
 


### PR DESCRIPTION
Noticed that when people analyzed the image they tended to always turn on the source markers to get accurate lines between stars, to save them a click and improve the experience now when source catalog is loaded it is shown by default and can still be checked off.

Also fixed a bug where we allowed the editing of source catalog markers, now the layer can no longer be edited.

<img width="802" alt="Screenshot 2024-08-30 at 3 06 47 PM" src="https://github.com/user-attachments/assets/85abc16a-861d-46c6-92a2-30d772e4bf17">
