### PR TITLE
rename session_id to camel case, loading bar button, immediate polling

### DIFF
--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -118,7 +118,7 @@ onMounted(() => {
     >
       <!-- The operations bar list goes here -->
       <operation-pipeline
-        :session_id="data.id"
+        :session-id="data.id"
         :operations="data.operations"
         :active="props.active"
         @operation-completed="addCompletedOperation"

--- a/src/components/DataSession/LoadBarButton.vue
+++ b/src/components/DataSession/LoadBarButton.vue
@@ -32,10 +32,7 @@ defineProps({
   left: 0;
   background-color: var(--tan);
   height: 100%;
-  width: 0%;
-  opacity: 1;
   transition: 0.3s;
-  z-index: 1;
   }
 
 .selected .progress-bar {

--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -3,7 +3,7 @@ import { ref, watch, onBeforeUnmount } from 'vue'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
 import { fetchApiCall, handleError } from '@/utils/api'
-import LoadBarButton from '@/components/Global/LoadBarButton'
+import LoadBarButton from '@/components/DataSession/LoadBarButton.vue'
 
 const store = useConfigurationStore()
 const alertStore = useAlertsStore()
@@ -70,7 +70,7 @@ async function pollOperationCompletion(operationID) {
       }
     }
     else{
-      console.error('No response on status for operation:', operationID)
+      alertStore.setAlert('error', 'Operation status not found')
     }
   }
 
@@ -166,10 +166,6 @@ onBeforeUnmount(() => {
   font-weight: 600;
   border-style: none;
   color: var(--metal);
-}
-
-.selected {
-  color: var(--tan);
 }
 
 @media (max-width: 1200px) {

--- a/src/components/Global/LoadBarButton.vue
+++ b/src/components/Global/LoadBarButton.vue
@@ -1,0 +1,44 @@
+<script setup>
+defineProps({
+  progress: {
+    type: Number,
+    required: true,
+  }
+})
+
+</script>
+
+<template>
+  <v-btn class="loadBarButton">
+    <slot />
+    <div
+      class="progress-bar"
+      :style="{ width: progress + '%' }"
+    />
+  </v-btn>
+</template>
+<style scoped>
+.loadBarButton{
+  position: relative;
+  overflow: hidden;
+  background-color: var(--dark-blue);
+}
+:slotted(p) {
+  z-index: 2;
+}
+.progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--tan);
+  height: 100%;
+  width: 0%;
+  opacity: 1;
+  transition: 0.3s;
+  z-index: 1;
+  }
+
+.selected .progress-bar {
+  background-color: var(--dark-green);
+}
+</style>


### PR DESCRIPTION
Improved the progress bar to be part of the button instead of disconnected underneath it
also renamed sessionId to be camel case to fix a vue linting error
we also now poll the button's operation status immediately and then set an interval so we can instantly update the state without having to wait 

old loading bar

https://github.com/user-attachments/assets/ece53212-553d-47f6-8fc1-8a43bfcf85dc



example with the button selected to show that it works with the selected color

https://github.com/user-attachments/assets/93dc2adf-d155-428b-bc15-a894f8210eb1



example with no selections


https://github.com/user-attachments/assets/fca03733-e8ce-4767-b2c3-5ee728f7cce4


