### PR TITLE
Analysis data improvements

### DIFF
--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -45,7 +45,7 @@ const handleClick = (index) => {
 
 const handleDoubleClick = (image) => {
   clearTimeout(doubleClickTimer)
-  alertsStore.setAlert('loading', `Opening ${image?.basename} for analysis`)
+  alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   launchAnalysis(image)
 }
 

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -54,7 +54,7 @@ function select(tableSelectedImages){
 
 function launchAnalysis(image){
   try {
-    alertsStore.setAlert('loading', `Opening ${image?.basename} for analysis`)
+    alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
     if (!image.largeCachedUrl) {
       image.largeCachedUrl = ref('')
       const url = image.large_url || image.largeThumbUrl || ''

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -3,6 +3,7 @@ import { ref, computed, defineProps } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useAlertsStore } from '@/stores/alerts'
 import { useConfigurationStore } from '@/stores/configuration'
+import { siteIDToName } from '@/utils/common'
 import FilterBadge from '@/components/Global/FilterBadge.vue'
 import ImageAnalyzer from '../Project/ImageAnalysis/ImageAnalyzer.vue'
 
@@ -93,6 +94,9 @@ function launchAnalysis(image){
     <template #[`header.data-table-select`] /> <!--Hides select all checkbox-->
     <template #[`item.observation_date`]="{ item }">
       <p>{{ new Date(item.observation_date).toLocaleString() }}</p>
+    </template>
+    <template #[`item.site_id`]="{ item }">
+      <p>{{ siteIDToName(item.site_id) }}</p>
     </template>
     <template #[`item.FILTER`]="{ item }">
       <filter-badge

--- a/src/stores/alerts.js
+++ b/src/stores/alerts.js
@@ -8,7 +8,7 @@ import { defineStore } from 'pinia'
 export const useAlertsStore = defineStore('alerts', {
   state() {
     return{
-      alertType: 'default', // alert type to display ('success', 'error', 'warning', 'info', 'loading')
+      alertType: 'info', // alert type to display ('success', 'error', 'warning', 'info')
       alertText: 'default alert text', // text displayed in alert
       alertTimeStamp: '0' // timestamp of the last alert, used for watching in AlertToast.vue
     }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -3,4 +3,19 @@ const calculateColumnSpan = (imageCount, imagesPerRow) => {
   return totalColumns
 }
 
-export { calculateColumnSpan }
+function siteIDToName(siteID) {
+  const siteIDMap = {
+    'COJ': 'Siding Spring Observatory',
+    'CPT': 'South African Astronomical Observatory',
+    'TFN': 'Teide Observatory',
+    'LSC': 'Cerro Tololo Inter-American Observatory',
+    'ELP': 'McDonald Observatory',
+    'OGG': 'Haleakala Observatory',
+    'TLV': 'Wise Observatory',
+    'NGQ': 'Ali Observatory'
+  }
+
+  return siteIDMap[siteID?.toUpperCase()] || siteID
+}
+
+export { calculateColumnSpan, siteIDToName }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -5,14 +5,14 @@ const calculateColumnSpan = (imageCount, imagesPerRow) => {
 
 function siteIDToName(siteID) {
   const siteIDMap = {
-    'COJ': 'Siding Spring Observatory',
-    'CPT': 'South African Astronomical Observatory',
-    'TFN': 'Teide Observatory',
-    'LSC': 'Cerro Tololo Inter-American Observatory',
-    'ELP': 'McDonald Observatory',
-    'OGG': 'Haleakala Observatory',
-    'TLV': 'Wise Observatory',
-    'NGQ': 'Ali Observatory'
+    'COJ': 'Siding Spring Observatory @ New South Wales',
+    'CPT': 'South African Astronomical Observatory @ Cape Town',
+    'TFN': 'Teide Observatory @ Tenerife',
+    'LSC': 'Cerro Tololo Inter-American Observatory @ Chile',
+    'ELP': 'McDonald Observatory @ University of Texas',
+    'OGG': 'Haleakala Observatory @ Maui',
+    'TLV': 'Wise Observatory @ Tel Aviv University',
+    'NGQ': 'Ali Observatory @ Tibet',
   }
 
   return siteIDMap[siteID?.toUpperCase()] || siteID


### PR DESCRIPTION
Requested by Micheal to improve some aspects of the analysis view

- Site codes are now replaced with their full site name
- There is now an info button to view the Image Data (FITS headers)
- Other UI improvements


<img width="1554" alt="Screenshot 2024-10-11 at 1 20 41 PM" src="https://github.com/user-attachments/assets/ec674352-02e0-4769-8375-c3508c69e57d">

<img width="1542" alt="Screenshot 2024-11-01 at 10 41 27 AM" src="https://github.com/user-attachments/assets/193c4ada-e70a-4c52-83da-2fefeb0de602">
