### PR TITLE
moved click event to the title instead of panel

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -224,9 +224,8 @@ onMounted(() => {
       <v-expansion-panel
         v-for="proposal in userDataStore.proposals"
         :key="proposal.id"
-        @click="loadProposals('reduction_level=91')"
       >
-        <v-expansion-panel-title>
+        <v-expansion-panel-title @click="loadProposals('reduction_level=91')">
           <p>{{ proposal.title }}</p>
         </v-expansion-panel-title>
         <v-expansion-panel-text>


### PR DESCRIPTION
Problem: Clicking on the background of the grid or empty space that was part of the expansion panel the images would perform a reload when they didn't need to. 
Solution: This is now fixed by moving the click event to the title bar so only that will reload the page.
Cause: Not sure, as this code wasn't changed recently and it worked before. Maybe Vuetify changed something about the bounds of expansion panels

Before Fix:

https://github.com/user-attachments/assets/743aceff-a306-4391-b5f0-c980a0253972

After Fix:

https://github.com/user-attachments/assets/00dfdfb5-6234-47d5-ae6f-524062157d34

