### PR TITLE
removed clearing of imagesByProposal

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -58,8 +58,6 @@ function deselectAllImages() {
 }
 
 async function loadProposals(option){
-  imagesByProposal.value = {}
-
   // Update the URL with the current filters
   router.push({ query: { ra: ra.value, dec: dec.value, observationId: observationId.value, search: search.value, startDate: startDate.value.toISOString(), endDate: endDate.value.toISOString() } })
 


### PR DESCRIPTION
This was leftover from earlier development. The left over side-effect is that whenever images are loaded the entire dictionary of current loaded images is cleared. 
This clears all the loaded images, but Line 101 `imagesByProposal.value[proposalID] = responseData.results` already replaces the current images with the new "filter set".

Best way to test this is by using the branch yourself and observing the difference.