### PR TITLE
fix hydration error for vue config

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,16 +1,27 @@
 const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
-	transpileDependencies: true,
+  transpileDependencies: true,
 
-	pluginOptions: {
-		vuetify: {
-			// https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vuetify-loader
-		}
-	},
-	devServer: {
-		headers: {
-			'Cross-Origin-Embedder-Policy':'require-corp',
-			'Cross-Origin-Opener-Policy':'same-origin',
-		},
-	}
+  pluginOptions: {
+    vuetify: {
+      // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vuetify-loader
+    }
+  },
+  devServer: {
+    headers: {
+      'Cross-Origin-Embedder-Policy':'require-corp',
+      'Cross-Origin-Opener-Policy':'same-origin',
+    },
+  },
+
+  chainWebpack: (config) => {
+    config.plugin('define').tap((definitions) => {
+      Object.assign(definitions[0], {
+        __VUE_OPTIONS_API__: 'true',
+        __VUE_PROD_DEVTOOLS__: 'false',
+        __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false'
+      })
+      return definitions
+    })
+  }
 })


### PR DESCRIPTION
Fixes a hydration warning that wouldn't break the website, but it does tell Vue which packages to include at runtime. Without it we would be including some dev tools packages by default so this helps reduce the build size and overhead.

<img width="1567" alt="Screenshot 2024-11-08 at 11 21 41 AM" src="https://github.com/user-attachments/assets/84e7cc4a-6b89-40fe-b172-bc6419d07e33">

In the above image I ran the old code which shows the warning, then I stopped the server, ran it with the options set, and the warning is gone.