### PR TITLE
Project View Filter changes

### DIFF
--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -109,8 +109,12 @@ watch(() => [startDate.value, endDate.value], async () => {
 })
 
 watch(() => [ra.value, dec.value, observationId.value], async () => {
-  if(ra.value && dec.value && isNaN(ra.value) || isNaN(dec.value)){
-    alertsStore.setAlert('warning', `RA and DEC must be a number ${isNaN(ra.value) ? ra.value : ''} ${isNaN(dec.value) ? dec.value : ''}`)
+  // Clear the Search filter if the ra or dec field is cleared
+  if(!ra.value || !dec.value){
+    search.value = ''
+  }
+  if((ra.value && isNaN(ra.value)) || (dec.value && isNaN(dec.value))){
+    alertsStore.setAlert('warning', 'RA and DEC must be a number')
   }
   if(observationId.value && isNaN(observationId.value)){
     alertsStore.setAlert('warning', `Observation ID is not a number ${observationId.value}`)


### PR DESCRIPTION
Before if you searched M1 in the search field ra, and dec fields would be filled out. But when you cleared one of them the search field would still say M1. Now clearing either the ra or dec field clears the search field as well.

Also fixed the logic check/message for the nan check on ra and dec. Before it would not check properly for undefined and print "RA and DEC must be a number undefined undefined" if dec was Nan