### PR TITLE
Broken slider for v-tabs and routerlink

### DIFF
--- a/src/components/Global/NavBar.vue
+++ b/src/components/Global/NavBar.vue
@@ -21,14 +21,20 @@ import UserMenu from './UserMenu.vue'
       text="DATALAB"
       class="nav-text"
     />
-    <v-tabs>
-      <RouterLink to="/projects">
+    <v-tabs hide-slider>
+      <RouterLink
+        active-class="active-tab"
+        to="/projects"
+      >
         <v-tab
           text="Projects"
           class="nav-text"
         />
       </RouterLink>
-      <RouterLink to="/datasessions">
+      <RouterLink
+        active-class="active-tab"
+        to="/datasessions"
+      >
         <v-tab
           text="Data Sessions"
           class="nav-text"
@@ -45,5 +51,8 @@ import UserMenu from './UserMenu.vue'
   color: var(--tan);
   font-weight: 600;
   font-size: 1rem;
+  }
+  .active-tab {
+    background-color: var(--dark-blue);
   }
 </style>


### PR DESCRIPTION
slider for vuetify was not properly selecting the active tab, changed it to use the routerlink class selector with a matching background color to content

Post Fix

https://github.com/user-attachments/assets/39fceec4-7482-42ec-8e93-fe2f41e40edc

Pre Fix

https://github.com/user-attachments/assets/cf75aa16-8256-4ba6-84ad-3b2035199617

