### PR TITLE
convert blob content type and replace if with try catch

### DIFF
--- a/src/components/Project/ImageAnalysis/ImageDownloadMenu.vue
+++ b/src/components/Project/ImageAnalysis/ImageDownloadMenu.vue
@@ -24,17 +24,16 @@ defineEmits(['analysisAction'])
 const alertStore = useAlertsStore()
 
 function downloadLink(link, filename, fileType='file'){
-  if(!link){
-    alertStore.setAlert('error', `No ${fileType} available for download`)
-    return
+  try{
+    const a = document.createElement('a')
+    a.href = link
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+  } catch (error) {
+    alertStore.setAlert('error', `Failed to download ${fileType} file`)
   }
-  // Create a link element and click it to download the file
-  const a = document.createElement('a')
-  a.href = link
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
 }
 
 </script>

--- a/src/stores/thumbnails.js
+++ b/src/stores/thumbnails.js
@@ -114,6 +114,8 @@ export const useThumbnailsStore = defineStore('thumbnails', {
       if (cachedUrl === undefined || cachedUrl === ''){
         return getImageFromBasename(size, archive, url, basename).then((response) => {
           if (response){
+            // Convert to image/jpeg for caching as S3 presigned URLs blobs default to binary/octet-stream
+            response.headers.set('content-type', 'image/jpeg')
             return response.blob()
           }
           return undefined


### PR DESCRIPTION
Problem: When trying to download JPEGs of Datalab outputs you would get a binary file with no type

Cause:
After using print statements it turned out that the presigned urls that came from the Datalab archive were being interpreted as MIME type `binary/octet-stream`.

This caused the `blob` and `createObjectUrl` methods used to cache the JPEG to treat it as a binary file instead of an image, so downloading it wouldn't download as a JPEG.

Solution: Convert the MIME context-type of the response to `image/jpeg` to make sure any images coming in are handled as JPEGs.