### PR TITLE
modify blob object instead of headers

### DIFF
--- a/src/stores/thumbnails.js
+++ b/src/stores/thumbnails.js
@@ -114,14 +114,14 @@ export const useThumbnailsStore = defineStore('thumbnails', {
       if (cachedUrl === undefined || cachedUrl === ''){
         return getImageFromBasename(size, archive, url, basename).then((response) => {
           if (response){
-            // Convert to image/jpeg for caching as S3 presigned URLs blobs default to binary/octet-stream
-            response.headers.set('content-type', 'image/jpeg')
             return response.blob()
           }
           return undefined
         })
           .then((responseBlob) => {
             if (responseBlob) {
+              // Convert to image/jpeg for caching as S3 presigned URLs blobs default to binary/octet-stream
+              responseBlob = new Blob([responseBlob], {type: 'image/jpeg'})
               const responseUrl = URL.createObjectURL(responseBlob)
               if (size == 'large'){
                 this.largeThumbnailsCache.set(basename, responseUrl)


### PR DESCRIPTION
When I deployed the changes to prod and tested it errors with 
`Uncaught (in promise) TypeError: Headers.set: Headers are immutable and cannot be modified.
    cacheImage thumbnails.js:118`

Instead of mutating the headers creating a new blob from the blob we have but with a new content-type