### PR TITLE
Toggle Image Sources with Icon instead of leaflet menu

### DIFF
--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -29,6 +29,7 @@ const lineProfile = ref([])
 const lineProfileLength = ref()
 const startCoords = ref()
 const endCoords = ref()
+const catalogToggle = ref(true)
 const catalog = ref([])
 const positionAngle = ref()
 const headerDialog = ref(false)
@@ -36,7 +37,12 @@ const headerData = ref({})
 const fluxSliderRange = ref([0, 10000])
 
 const filteredCatalog = computed(() => {
-  return catalog.value.filter((source) => source.flux >= fluxSliderRange.value[0] && source.flux <= fluxSliderRange.value[1])
+  if(catalogToggle.value){
+    return catalog.value.filter((source) => source.flux >= fluxSliderRange.value[0] && source.flux <= fluxSliderRange.value[1])
+  }
+  else{
+    return []
+  }
 })
 
 function closeDialog() {
@@ -147,13 +153,17 @@ function showHeaderDialog() {
             rounded
             class="image-controls-sheet"
           >
-            <b>{{ filteredCatalog.length }} Sources with Flux between {{ fluxSliderRange[0] }} and {{ fluxSliderRange[1] }}</b>
+            <v-icon
+              icon="mdi-flare"
+              :color="catalogToggle ? 'var(--light-blue)' : 'var(--tan)'"
+              @click="() => catalogToggle = !catalogToggle"
+            />
             <non-linear-slider
               v-model="fluxSliderRange"
-              prepend-icon="mdi-flare"
               :max="Math.max(...catalog.map((source) => source.flux))"
               :min="Math.min(...catalog.map((source) => source.flux))"
             />
+            <b>{{ filteredCatalog.length }} Sources with Flux between {{ fluxSliderRange[0] }} and {{ fluxSliderRange[1] }}</b>
           </v-sheet>
           <v-sheet
             class="line-plot-sheet"

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -114,7 +114,7 @@ function showHeaderDialog() {
     :model-value="modelValue"
     fullscreen
   >
-    <v-sheet class="analysis-sheet">
+    <v-sheet class="analysis-page">
       <v-toolbar
         class="analysis-toolbar"
         density="comfortable"
@@ -149,24 +149,45 @@ function showHeaderDialog() {
         />
         <div class="side-panel-container">
           <v-sheet
-            v-if="catalog.length"
+            v-if="image.site_id || image.telescope_id || image.instrument_id || image.observation_date"
+            class="side-panel-item pa-4"
             rounded
-            class="image-controls-sheet"
           >
-            <v-icon
-              icon="mdi-flare"
-              :color="catalogToggle ? 'var(--light-blue)' : 'var(--tan)'"
-              @click="() => catalogToggle = !catalogToggle"
-            />
-            <non-linear-slider
-              v-model="fluxSliderRange"
-              :max="Math.max(...catalog.map((source) => source.flux))"
-              :min="Math.min(...catalog.map((source) => source.flux))"
-            />
-            <b>{{ filteredCatalog.length }} Sources with Flux between {{ fluxSliderRange[0] }} and {{ fluxSliderRange[1] }}</b>
+            <p v-if="image.site_id">
+              <v-icon icon="mdi-earth" /> {{ siteIDToName(image.site_id) }}
+            </p>
+            <p v-if="image.telescope_id">
+              <v-icon icon="mdi-telescope" /> {{ image.telescope_id }}
+            </p>
+            <p v-if="image.instrument_id">
+              <v-icon icon="mdi-camera" /> {{ image.instrument_id }}
+            </p>
+            <p v-if="image.observation_date">
+              <v-icon icon="mdi-clock" /> {{ new Date(image.observation_date).toLocaleString() }}
+            </p>
           </v-sheet>
           <v-sheet
-            class="line-plot-sheet"
+            v-if="catalog.length"
+            rounded
+            class="side-panel-item image-controls-sheet"
+          >
+            <b>{{ filteredCatalog.length }} Sources with Flux between {{ fluxSliderRange[0] }} and {{ fluxSliderRange[1] }}</b>
+            <div class="d-flex justify-end">
+              <v-icon
+                class="mr-4 mt-1"
+                icon="mdi-flare"
+                :color="catalogToggle ? 'var(--light-blue)' : 'var(--tan)'"
+                @click="() => catalogToggle = !catalogToggle"
+              />
+              <non-linear-slider
+                v-model="fluxSliderRange"
+                :max="Math.max(...catalog.map((source) => source.flux))"
+                :min="Math.min(...catalog.map((source) => source.flux))"
+              />
+            </div>
+          </v-sheet>
+          <v-sheet
+            class="side-panel-item line-plot-sheet"
             rounded
           >
             <line-plot
@@ -186,10 +207,6 @@ function showHeaderDialog() {
     width="auto"
   >
     <v-sheet class="pa-12">
-      <p><v-icon icon="mdi-earth" /> {{ siteIDToName(image.site_id) ?? 'Missing Site' }}</p>
-      <p><v-icon icon="mdi-telescope" /> {{ image.telescope_id ?? 'Missing Telescope ID' }}</p>
-      <p><v-icon icon="mdi-camera" /> {{ image.instrument_id ?? 'Missing Instrument ID' }} </p>
-      <p><v-icon icon="mdi-clock" /> {{ new Date(image.observation_date).toLocaleString() }}</p>
       <h1 class="mb-4 mt-4">
         FITS Headers
       </h1>
@@ -210,15 +227,11 @@ function showHeaderDialog() {
   </v-dialog>
 </template>
 <style scoped>
-a{
-  color: var(--tan);
-}
-.v-sheet{
+/* Main Sections */
+.analysis-page{
   background-color: var(--dark-blue);
   color: var(--tan);
   font-family: 'Open Sans', sans-serif;
-}
-.analysis-sheet{
   max-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -233,22 +246,22 @@ a{
   flex-direction: row;
   padding: 1rem;
 }
+/* Side Panel */
 .side-panel-container {
   display: flex;
   flex-direction: column;
-  margin-left: 10px;
+  margin-left: 1rem;
   width: 45vw;
 }
-.image-controls-sheet{
+.side-panel-item{
   padding: 1rem;
-  margin-bottom: 1rem;
   color: var(--tan);
   background-color: var(--metal);
+  margin-bottom: 1rem;
 }
 .line-plot-sheet {
-  padding: 1rem;
-  background-color: var(--metal);
   height: 100%;
+  margin-bottom: 0;
 }
 /* FITS Header Info Table */
 .v-table{

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -173,8 +173,11 @@ function showHeaderDialog() {
           >
             <b>{{ filteredCatalog.length }} Sources with Flux between {{ fluxSliderRange[0] }} and {{ fluxSliderRange[1] }}</b>
             <div class="d-flex justify-end">
-              <v-icon
-                class="mr-4 mt-1"
+              <v-btn
+                class="mr-2"
+                variant="text"
+                title="Toggle Catalog"
+                density="comfortable"
                 icon="mdi-flare"
                 :color="catalogToggle ? 'var(--light-blue)' : 'var(--tan)'"
                 @click="() => catalogToggle = !catalogToggle"

--- a/src/components/Project/ImageAnalysis/ImageViewer.vue
+++ b/src/components/Project/ImageAnalysis/ImageViewer.vue
@@ -27,7 +27,6 @@ let initialCenter = [0, 0]
 let initialZoom = 1
 let lineLayer = null
 let catalogLayerGroup = null
-let catalogLayerControl = null
 const imageWidth = ref(0)
 const imageHeight = ref(0)
 const leafletDiv = ref(null)
@@ -207,11 +206,6 @@ function createCatalogLayer(){
   } else {
     catalogLayerGroup = new L.LayerGroup(sourceCatalogMarkers)
     catalogLayerGroup.addTo(imageMap)
-  }
-
-  // Layer control allows the toggling of layers on the map
-  if(!catalogLayerControl){
-    catalogLayerControl = new L.Control.Layers(null, { 'Source Catalog': catalogLayerGroup }, { collapsed: false }).addTo(imageMap)
   }
 }
 


### PR DESCRIPTION
Small improvement to consolidate controlling the source catalog with the icon next to the range slider. This will be more intuitive to the user as ot follows better UX principles by co-locating related functions. 

Also moved the image info back to the top

Old position of source catalog control
![Screenshot 2025-01-22 at 4 04 17 PM](https://github.com/user-attachments/assets/ad1efa1d-b370-4cef-a1e1-72c374b22407)

New co-located control

https://github.com/user-attachments/assets/6b77b30e-c016-494d-b4d9-f135f63f366c

