### PR TITLE
fixes one way difference bug, now checks symmetrically

### DIFF
--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -45,9 +45,10 @@ const alertsStore = useAlertsStore()
 const thumbnailsStore = useThumbnailsStore()
 const configurationStore = useConfigurationStore()
 
-function select(tableSelectedImages){
-  // check for the difference between selectedImages and event and return the unique indexes
-  for (const index of tableSelectedImages.filter(x => !props.selectedImages.includes(x))) {
+// checks difference between table and parent selected images and emits the difference
+function select(tableModel){
+  const symDiffSelected = tableModel.filter(image => !props.selectedImages.includes(image)).concat(props.selectedImages.filter(image => !tableModel.includes(image)))
+  for (const index of symDiffSelected) {
     emit('selectImage', index)
   }
 }


### PR DESCRIPTION
Bug: In the list view checking an image would select it to be added to a proposal but unchecking it wouldn't

Cause: I wasn't checking the [symmetrical difference](https://stackoverflow.com/questions/1187518/how-to-get-the-difference-between-two-arrays-in-javascript) between the sets and so it would only find the difference between the table and proposal but not vice versa

Fix: concat the includes check both ways to find the total difference

