### PR TITLE
Update/analysis improvements

### DIFF
--- a/src/components/Project/ImageAnalysis/FitsHeaderTable.vue
+++ b/src/components/Project/ImageAnalysis/FitsHeaderTable.vue
@@ -1,0 +1,56 @@
+<script setup>
+import { ref } from 'vue'
+
+const search = ref('')
+
+const props = defineProps({
+  headerData: {
+    type: Object,
+    required: true
+  }
+})
+
+const headerDataKeyValueList = Object.entries(props.headerData)
+
+const tableHeaders = ref([
+  { title: 'Key', key:'0' },
+  { title: 'Value', sortable: false, key:'1' },
+])
+
+</script>
+<template>
+  <v-sheet class="fits-header-sheet pa-12">
+    <div class="d-flex justify-space-between align-center">
+      <h1 class="mb-4 mt-4">
+        FITS Headers
+      </h1>
+      <v-text-field
+        v-model="search"
+        class="ml-6"
+        density="compact"
+        prepend-inner-icon="mdi-magnify"
+        label="Search"
+        flat
+        hide-details
+        single-line
+      />
+    </div>
+    <v-data-table
+      v-model:search="search"
+      :headers="tableHeaders"
+      :items="headerDataKeyValueList"
+      :items-per-page="headerDataKeyValueList.length"
+      hide-default-footer
+      hide-no-data
+    />
+  </v-sheet>
+</template>
+<style scoped>
+.fits-header-sheet{
+  background-color: var(--dark-blue);
+  color: var(--tan);
+}
+.v-data-table{
+  background-color: var(--dark-blue);
+}
+</style>

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -114,6 +114,7 @@ function showHeaderDialog() {
 <template>
   <v-dialog
     :model-value="modelValue"
+    persistent="true"
     fullscreen
   >
     <v-sheet class="analysis-page">
@@ -140,6 +141,7 @@ function showHeaderDialog() {
         />
         <v-btn
           icon="mdi-close"
+          color="var(--cancel)"
           @click="closeDialog()"
         />
       </v-toolbar>

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -114,7 +114,7 @@ function showHeaderDialog() {
 <template>
   <v-dialog
     :model-value="modelValue"
-    persistent="true"
+    persistent
     fullscreen
   >
     <v-sheet class="analysis-page">

--- a/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
+++ b/src/components/Project/ImageAnalysis/ImageAnalyzer.vue
@@ -8,6 +8,7 @@ import LinePlot from './LinePlot.vue'
 import FilterBadge from '@/components/Global/FilterBadge.vue'
 import NonLinearSlider from '@/components/Global/NonLinearSlider.vue'
 import ImageDownloadMenu from '@/components/Project/ImageAnalysis/ImageDownloadMenu.vue'
+import FitsHeaderTable from './FitsHeaderTable.vue'
 import { siteIDToName } from '@/utils/common'
 
 const props = defineProps({
@@ -89,6 +90,7 @@ function handleAnalysisOutput(response, action, action_callback){
   }
 }
 
+// Toggles header dialog visibility, fetches headers from archive if they are not present
 function showHeaderDialog() {
   if(headerData.value && Object.keys(headerData.value).length > 0) {
     headerDialog.value = true
@@ -207,26 +209,10 @@ function showHeaderDialog() {
   </v-dialog>
   <v-dialog
     v-model="headerDialog"
-    width="auto"
+    width="600px"
+    height="85vh"
   >
-    <v-sheet class="pa-12">
-      <h1 class="mb-4 mt-4">
-        FITS Headers
-      </h1>
-      <v-table>
-        <tbody>
-          <tr
-            v-for="(value, key) in headerData"
-            :key="key"
-          >
-            <td class="table_key">
-              {{ key }}
-            </td>
-            <td>{{ value }}</td>
-          </tr>
-        </tbody>
-      </v-table>
-    </v-sheet>
+    <fits-header-table :header-data="headerData" />
   </v-dialog>
 </template>
 <style scoped>
@@ -265,15 +251,5 @@ function showHeaderDialog() {
 .line-plot-sheet {
   height: 100%;
   margin-bottom: 0;
-}
-/* FITS Header Info Table */
-.v-table{
-  background-color: var(--dark-blue);
-  color: var(--tan);
-  max-width: 60ch;
-}
-.table_key{
-  font-weight: bold;
-  font-size: large;
 }
 </style>

--- a/src/components/Project/ImageAnalysis/ImageDownloadMenu.vue
+++ b/src/components/Project/ImageAnalysis/ImageDownloadMenu.vue
@@ -39,6 +39,7 @@ function downloadLink(link, filename, fileType='file'){
 </script>
 <template>
   <v-speed-dial
+    variant="text"
     location="left center"
     transition="fade-transition"
   >
@@ -51,24 +52,27 @@ function downloadLink(link, filename, fileType='file'){
     <v-btn
       v-if="props.fitsUrl"
       key="1"
+      class="file-download"
       text=".FITS"
       @click="downloadLink(props.fitsUrl, props.imageName, 'FITs')"
     />
     <v-btn
       key="2"
+      class="file-download"
       text=".TIF"
       @click="$emit('analysisAction', 'get-tif', {'basename': props.imageName}, downloadLink)"
     />
     <v-btn
       v-if="props.jpgUrl"
       key="3"
+      class="file-download"
       text=".JPG"
       @click="downloadLink(props.jpgUrl, props.imageName, 'JPG')"
     />
   </v-speed-dial>
 </template>
 <style scoped>
-.v-btn{
-  background-color: var(--metal);
+.file-download {
+  background-color: var(--light-blue);
 }
 </style>


### PR DESCRIPTION
A Couple of bug fixes, changes, and imrpovements I've been wanting to add to the analysis page.

Changes
- The analysis image auto fits as best it can to the map viewing square. Previously Datalab outputs would be much bigger and you couldn't zoom out to see the whole thing. 
- Fits Header info table is now searchable
- Can no longer accidentally close the analysis by spam clicking (hits the v-overlay component thats part of v-dialog, closing the analysis view) so clicking to open an image is more reliable
- file download buttons are now a different color than the background

Example of previous image fitting

https://github.com/user-attachments/assets/3a4a1ce3-4442-428c-9d1b-cd35123c8bf0

Example of new image fitting

https://github.com/user-attachments/assets/73d7f79b-634c-4b21-91b9-814086c494bf

Searchable fits headers
<img width="1076" alt="Screenshot 2025-01-28 at 4 10 09 PM" src="https://github.com/user-attachments/assets/69c45f46-c402-4fcb-8dec-50faee48722d" />

