### PR TITLE
fixes polling management for deleted in progress operations

### DIFF
--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -109,11 +109,17 @@ function processOperations() {
   })
 }
 
-function stopPollingById(operationID) {
-  if (operationID in operationPollingTimers){
-    clearInterval(operationPollingTimers[operationID])
-    delete operationPollingTimers[operationID]
-  }
+function stopPollingById(operationIDs) {
+  const ids = Array.isArray(operationIDs) ? operationIDs : [operationIDs]
+
+  ids.forEach(id => {
+    if (operationPollingTimers[id]) {
+      clearInterval(operationPollingTimers[id])
+      delete operationPollingTimers[id]
+    }
+  })
+
+  refreshOperations()
 }
 
 async function pollOperationCompletion(operation) {
@@ -250,7 +256,7 @@ watch(
               :selected-operation="selectedOperation"
               @operation-completed="addCompletedOperation"
               @select-operation="selectOperation"
-              @operation-was-deleted="refreshOperations"
+              @operation-was-deleted="stopPollingById"
               @view-graph="tab = 'graph'"
             />
             <v-btn

--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -50,10 +50,10 @@ function openDeleteOperationDialog(operation) {
   showDeleteDialog.value = true
 }
 
-function itemDeleted(){
+function itemDeleted(deletedIds) {
   // Reset the selected operation after its deleted, otherwise the next operation will be selected 
   emit('selectOperation', -1)
-  emit('operationWasDeleted')
+  emit('operationWasDeleted', deletedIds)
 }
 
 function operationStateToClass(operation) {
@@ -114,7 +114,7 @@ function operationStateToClass(operation) {
     v-model="showDeleteDialog"
     :session-id="sessionId"
     :operations="deleteOperations"
-    @item-was-deleted="itemDeleted()"
+    @item-was-deleted="itemDeleted"
   />
 </template>
 

--- a/src/components/Global/DeleteOperationDialog.vue
+++ b/src/components/Global/DeleteOperationDialog.vue
@@ -24,7 +24,8 @@ const emit = defineEmits(['update:modelValue', 'itemWasDeleted'])
 const DIALOG_TITLE = 'DELETE OPERATION(S)'
 
 function itemDeleted(){
-  emit('itemWasDeleted', props.operationId)
+  const deletedIds = _.map(props.operations, 'id')
+  emit('itemWasDeleted', deletedIds)
   emit('update:modelValue', false)
 }
 


### PR DESCRIPTION
Bug: Deleting in progress operations didn't stop polling for them so they would keep hitting an error endpoint

Fix: replaced a missing prop with operation Ids that are deleted which is emitted to the parent component who removes the polling for those operations if they exist and refreshes the operation list

