### PR TITLE
adds setting to disable mid point when editing line

### DIFF
--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -109,7 +109,12 @@ function leafletSetup(){
     toggle: false,
   })
 
-  // Geoman settings setup
+  // Geoman settings
+  imageMap.pm.setGlobalOptions({
+    hideMiddleMarkers: true,
+  })
+
+  // Geoman controls
   imageMap.pm.addControls({
     position: 'topleft',
     drawMarker: false,
@@ -166,7 +171,7 @@ function handleEdit() {
 function requestLineProfile(latLngs) {
   // Check that there are two points to calculate the line length
   if (latLngs.length != 2){
-    alerts.setAlert('error', 'Please draw a line with two points')
+    alerts.setAlert('error', 'Cannot calculate line profile without two points')
     return
   }
 


### PR DESCRIPTION
disables the mid point when editing a geoman line, not needed for line profiles and just causes an error when used since it creates a line with 3 vertexes

Could have an interesting use case in the future where you can do a line profile thats is curved or follows a path, not sure how useful that would be