### PR TITLE
button to download scaled image, base64 download, store scaledZmin/Zmax

### DIFF
--- a/src/components/Analysis/ImageDownloadMenu.vue
+++ b/src/components/Analysis/ImageDownloadMenu.vue
@@ -26,7 +26,7 @@ const alertStore = useAlertsStore()
 const analysisStore = useAnalysisStore()
 
 function downloadBase64File(base64Data, filename, fileType='file'){
-  downloadFile('data:image/png;base64,' + base64Data, filename, fileType)
+  downloadFile('data:image/jpeg;base64,' + base64Data, filename, fileType)
 }
 
 function downloadFile(file, filename, fileType='file'){
@@ -70,13 +70,13 @@ function downloadFile(file, filename, fileType='file'){
       v-if="props.jpgUrl"
       key="3"
       class="file-download"
-      text=".PNG"
+      text=".JPG"
       @click="downloadFile(props.jpgUrl, props.imageName, 'JPG')"
     />
     <v-btn
       key="4"
       class="file-download"
-      text="Scaled .PNG"
+      text="Scaled .JPG"
       @click="$emit('analysisAction', 'get-jpg', {'basename': props.imageName, 'zmin': analysisStore.scaledZmin, 'zmax': analysisStore.scaledZmax}, downloadBase64File)"
     />
   </v-speed-dial>

--- a/src/components/Analysis/ImageDownloadMenu.vue
+++ b/src/components/Analysis/ImageDownloadMenu.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { useAlertsStore } from '@/stores/alerts'
+import { useAnalysisStore } from '@/stores/analysis'
 
 const props = defineProps({
   imageName: {
@@ -22,15 +23,18 @@ const props = defineProps({
 defineEmits(['analysisAction'])
 
 const alertStore = useAlertsStore()
+const analysisStore = useAnalysisStore()
 
-function downloadLink(link, filename, fileType='file'){
+function downloadBase64File(base64Data, filename, fileType='file'){
+  downloadFile('data:image/png;base64,' + base64Data, filename, fileType)
+}
+
+function downloadFile(file, filename, fileType='file'){
   try{
     const a = document.createElement('a')
-    a.href = link
+    a.href = file
     a.download = filename
-    document.body.appendChild(a)
     a.click()
-    document.body.removeChild(a)
   } catch (error) {
     alertStore.setAlert('error', `Failed to download ${fileType} file`)
   }
@@ -54,25 +58,32 @@ function downloadLink(link, filename, fileType='file'){
       key="1"
       class="file-download"
       text=".FITS"
-      @click="downloadLink(props.fitsUrl, props.imageName, 'FITs')"
+      @click="downloadFile(props.fitsUrl, props.imageName, 'FITs')"
     />
     <v-btn
       key="2"
       class="file-download"
       text=".TIF"
-      @click="$emit('analysisAction', 'get-tif', {'basename': props.imageName}, downloadLink)"
+      @click="$emit('analysisAction', 'get-tif', {'basename': props.imageName}, downloadFile)"
     />
     <v-btn
       v-if="props.jpgUrl"
       key="3"
       class="file-download"
-      text=".JPG"
-      @click="downloadLink(props.jpgUrl, props.imageName, 'JPG')"
+      text=".PNG"
+      @click="downloadFile(props.jpgUrl, props.imageName, 'JPG')"
+    />
+    <v-btn
+      key="4"
+      class="file-download"
+      text="Scaled .PNG"
+      @click="$emit('analysisAction', 'get-jpg', {'basename': props.imageName, 'zmin': analysisStore.scaledZmin, 'zmax': analysisStore.scaledZmax}, downloadBase64File)"
     />
   </v-speed-dial>
 </template>
 <style scoped>
 .file-download {
+  color: var(--off-white);
   background-color: var(--light-blue);
 }
 </style>

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -11,6 +11,8 @@ export const useAnalysisStore = defineStore('analysis', {
     rawData: null, // raw data from the analysis/raw_data endpoint
     zmin: null, // minimum z value of the raw data
     zmax: null, // maximum z value of the raw data
+    scaledZmin: null, // minimum z value of the scaled data
+    scaledZmax: null, // maximum z value of the scaled data
     imageUrl: '', // URL of the image to display
     imageWidth: null, // width of the image in pixels
     imageHeight: null, // height of the image in pixels

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -86,6 +86,9 @@ function handleAnalysisOutput(response, action, action_callback){
   case 'get-tif':
     action_callback(response.tif_url, props.image.basename, 'TIF')
     break
+  case 'get-jpg':
+    action_callback(response.jpg_base64, props.image.basename, 'base64')
+    break
   default:
     console.error('Invalid action:', action)
     break
@@ -137,6 +140,8 @@ async function instantiateScalerWorker(){
 }
 
 function updateScaling(min, max){
+  analysisStore.scaledZmin = min
+  analysisStore.scaledZmax = max
   imgWorker.postMessage({scalePoints: [min, max]})
 }
 


### PR DESCRIPTION
Adds a new button called scaled png, that will download a scaled version of the analysis image based on the histogram slider's values

This PR should be merged after the corresponding backend PR that adds in the get-jpg endpoint is merged.