### PR TITLE
Revert "simplify sws container build (#174)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 !./.dockerignore
 !./.eslintrc.js
 !./babel.config.js
+!./Dockerfile
 !./jsconfig.json
 !./package.json
 !./package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,8 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
-FROM node:22 AS build
+FROM node:22
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY ./ .
 RUN npm run build
-
-FROM ghcr.io/static-web-server/static-web-server:2-alpine
-
-COPY --from=build /app/dist /app/dist
-WORKDIR /app
-
-RUN <<EOF cat > /etc/sws.toml
-[general]
-host = "0.0.0.0"
-port = 8080
-
-root = "/app/dist"
-health = true
-
-page-fallback = "/app/dist/index.html"
-
-[advanced]
-
-[[advanced.headers]]
-source = "**/*"
-[advanced.headers.headers]
-Cross-Origin-Embedder-Policy = "require-corp"
-Cross-Origin-Opener-Policy = "same-origin"
-EOF
-
-CMD ["static-web-server", "--config-file=/etc/sws.toml"]
-EXPOSE 8080/tcp

--- a/k8s/base/deploy-frontend/deploy.yaml
+++ b/k8s/base/deploy-frontend/deploy.yaml
@@ -17,12 +17,22 @@ spec:
       securityContext:
         fsGroup: 1000
       volumes:
+        - name: dist
+          emptyDir:
+            sizeLimit: 256Mi
         - name: app-config
           configMap:
             name: app-config
-      containers:
-        - name: default
+        - name: sws-config
+          configMap:
+            name: sws-config
+      initContainers:
+        - name: copy-static-files
           image: datalab-ui
+          command:
+            - "sh"
+            - "-c"
+            - "cp -r /app/dist/* /app/volume"
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -36,8 +46,38 @@ spec:
               cpu: 2000m
               memory: 512Mi
           volumeMounts:
+            - name: dist
+              mountPath: /app/volume
+      containers:
+        - name: default
+          image: ghcr.io/static-web-server/static-web-server:2
+          command:
+            - /static-web-server
+            - --config-file=/sws/sws.toml
+            - --root=/app/dist
+            - --health
+            - --port=8080
+            - --host=0.0.0.0
+            - --page-fallback=/app/dist/index.html
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 256Mi
+            limits:
+              cpu: 2000m
+              memory: 512Mi
+          volumeMounts:
+            - name: dist
+              mountPath: /app/dist
             - name: app-config
               mountPath: /app/dist/config
+            - name: sws-config
+              mountPath: /sws
           ports:
             - name: frontend
               containerPort: 8080

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,3 +14,6 @@ configMapGenerator:
   - name: app-config
     files:
       - config.json
+  - name: sws-config
+    files:
+      - sws.toml

--- a/k8s/base/sws.toml
+++ b/k8s/base/sws.toml
@@ -1,0 +1,7 @@
+[advanced]
+
+[[advanced.headers]]
+source = "**/*"
+[advanced.headers.headers]
+Cross-Origin-Embedder-Policy = "require-corp"
+Cross-Origin-Opener-Policy = "same-origin"


### PR DESCRIPTION
This reverts commit 633c3d1349464e6344d0dbeabebbf1e79789954b. Wasn't setting the COEP CORP headers properly as the error with `sharedArrayBuffer` re-occured. I didn't check the PR properly when merging it.