### PR TITLE
Image Analysis Optimizations, Refactors

### DIFF
--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -61,18 +61,21 @@ function processScalePoints(scalePoints) {
   const scale = 255 / (high16Bit - low16Bit)
   const len = imageData.data.length
 
+  const imageDataArray = imageDataObject.data
+  const srcData = imageData.data
+
   for (let i = 0; i < len; i++) {
-    const clippedValue = Math.max(low16Bit, Math.min(high16Bit, imageData.data[i]))
+    const clippedValue = Math.max(low16Bit, Math.min(high16Bit, srcData[i]))
     const normalizedValue = Math.floor((clippedValue - low16Bit) * scale)
     const gammaCorrected = gammaTable[normalizedValue]
 
     if(sharedArray) sharedArray[i] = gammaCorrected
 
     const j = i * 4
-    imageDataObject.data[j] = gammaCorrected
-    imageDataObject.data[j + 1] = gammaCorrected
-    imageDataObject.data[j + 2] = gammaCorrected
-    imageDataObject.data[j + 3] = 255
+    imageDataArray[j] = gammaCorrected
+    imageDataArray[j + 1] = gammaCorrected
+    imageDataArray[j + 2] = gammaCorrected
+    imageDataArray[j + 3] = 255
   }
   context.putImageData(imageDataObject, 0, 0)
   postMessage({'updateSharedArray': true})

--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -1,4 +1,4 @@
-var context, imageData, sharedArrayBuffer, sharedArray, gammaTable, imageDataObject, scalePointMessage
+var context, imageData, sharedArrayBuffer, sharedArray, gammaTable, outputImage, scalePointMessage
 let hasImageData = false
 let hasCanvas = false
  
@@ -15,7 +15,7 @@ onmessage = function(job) {
   if (payload.canvas) {
     // Init worker with the canvas, width, height, imageData, and sharedArrayBuffer
     context = payload.canvas.getContext('2d')
-    imageDataObject = new ImageData(payload.width, payload.height)
+    outputImage = new ImageData(payload.width, payload.height)
 
     if(payload.sharedArrayBuffer){
       sharedArrayBuffer = payload.sharedArrayBuffer
@@ -61,7 +61,7 @@ function processScalePoints(scalePoints) {
   const scale = 255 / (high16Bit - low16Bit)
   const len = imageData.data.length
 
-  const imageDataArray = imageDataObject.data
+  const outputImageData = outputImage.data
   const srcData = imageData.data
 
   for (let i = 0; i < len; i++) {
@@ -72,11 +72,11 @@ function processScalePoints(scalePoints) {
     if(sharedArray) sharedArray[i] = gammaCorrected
 
     const j = i * 4
-    imageDataArray[j] = gammaCorrected
-    imageDataArray[j + 1] = gammaCorrected
-    imageDataArray[j + 2] = gammaCorrected
-    imageDataArray[j + 3] = 255
+    outputImageData[j] = gammaCorrected
+    outputImageData[j + 1] = gammaCorrected
+    outputImageData[j + 2] = gammaCorrected
+    outputImageData[j + 3] = 255
   }
-  context.putImageData(imageDataObject, 0, 0)
+  context.putImageData(outputImage, 0, 0)
   postMessage({'updateSharedArray': true})
 }

--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -61,12 +61,12 @@ async function loadImageOverlay(imgSrc) {
   updateImageOverlay(imgSrc)
 
   /**
-     * This code ensures the image fills the map space and sets a minZoom level.
-     * Next tick is used here otherwise the methods will not work due to bugs in leaflets code. 
-     * 
-     * MinZoom needs to be set to a high negative value in the settings to over-fit the whole image
-     * then we fit the image and update the minZoom to the fitted zoom level.
-     */
+   * This code ensures the image fills the map space and sets a minZoom level.
+   * Next tick is used here otherwise the methods will not work due to bugs in leaflets code. 
+   * 
+   * MinZoom needs to be set to a high negative value in the settings to over-fit the whole image
+   * then we fit the image and update the minZoom to the fitted zoom level.
+   */
   nextTick(() => {
     imageMap.invalidateSize()
     imageMap.fitBounds(imageBounds)
@@ -77,9 +77,9 @@ async function loadImageOverlay(imgSrc) {
 
 // Replaces the current overlay (if it exists) with a new image
 function updateImageOverlay(imgSrc){
-  if (imageOverlay) {
+  if (imageOverlay && imageOverlay._url !== imgSrc) {
     imageOverlay.setUrl(imgSrc)
-  } else {
+  } else if (!imageOverlay) {
     imageOverlay = L.imageOverlay(imgSrc, imageBounds).addTo(imageMap)
   }
 }

--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -34,9 +34,7 @@ onMounted(() => leafletSetup())
 
 watch(() => props.catalog, () => createCatalogLayer())
 
-watch(() => analysisStore.imageUrl, async (newImageUrl, oldImageUrl) => {
-  if (!newImageUrl || newImageUrl === oldImageUrl) return
-
+watch(() => analysisStore.imageUrl, async (newImageUrl) => {
   if (!imageName) {
     await loadImageOverlay(newImageUrl)
     imageName = analysisStore.image.basename

--- a/src/components/Global/Scaling/HistogramSlider.vue
+++ b/src/components/Global/Scaling/HistogramSlider.vue
@@ -178,6 +178,7 @@ watch(
     <v-range-slider
       v-model="sliderRange"
       step="1"
+      :ripple="false"
       track-size="0"
       :track-color="backgroundColor"
       :track-fill-color="selectedColor"

--- a/src/components/Global/Scaling/HistogramSlider.vue
+++ b/src/components/Global/Scaling/HistogramSlider.vue
@@ -53,15 +53,14 @@ const gradient = computed(() => {
   // Initialize array with background color
   const gradientArray = new Array(bins.length).fill(backgroundColor)
   
-  // Fill selected range efficiently
+  // Fill selected range
   gradientArray.fill(selectedColor, Math.max(0, start), Math.min(bins.length, end + 1))
 
   return gradientArray
 })
 
 function sliderToBinValue(sliderValue) {
-  // Ensure sliderValue is within bounds before indexing bins
-  return props.bins[sliderValue] ?? props.bins[props.bins.length - 1]
+  return props.bins[sliderValue] ?? console.error('Slider value out of bounds')
 }
 
 /**

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -42,7 +42,7 @@ export const useAnalysisStore = defineStore('analysis', {
         return
       }
 
-      const url = this.imageUrl || this.image.largeCachedUrl
+      const url = this.imageUrl
       const img = new Image()
       img.src = url
       return new Promise((resolve) => {

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -36,13 +36,8 @@ export const useAnalysisStore = defineStore('analysis', {
       if (this.imageWidth && this.imageHeight) {
         return
       }
-      
-      if (!this.imageUrl) {
-        console.error('No image URL provided')
-        return
-      }
 
-      const url = this.imageUrl
+      const url = this.imageUrl || this.image.largeCachedUrl
       const img = new Image()
       img.src = url
       return new Promise((resolve) => {

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -231,7 +231,6 @@ function updateScaling(min, max){
         <v-expand-transition>
           <v-sheet
             v-if="analysisStore.imageScaleReady"
-            transition="fade-transition"
             class="side-panel-item"
             rounded
           >

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -121,7 +121,10 @@ async function instantiateScalerWorker(){
   catch (error) { return console.error('Failed to load scale data:', error) }
 
   // Create a new offscreen canvas for the worker
-  const offscreen = new OffscreenCanvas(analysisStore.imageWidth, analysisStore.imageHeight)
+  const imgScalingCanvas = document.createElement('canvas')
+  imgScalingCanvas.width = analysisStore.imageWidth
+  imgScalingCanvas.height = analysisStore.imageHeight
+  const offscreen = imgScalingCanvas.transferControlToOffscreen()
 
   // Post the image data to the worker
   imgWorker.postMessage({
@@ -133,7 +136,7 @@ async function instantiateScalerWorker(){
 
   // Image creation for leaflet map, clean up the old image url
   imgWorker.onmessage = () => {
-    offscreen.convertToBlob().then((blob) => {
+    imgScalingCanvas.toBlob((blob) => {
       if (analysisStore.imageUrl) URL.revokeObjectURL(analysisStore.imageUrl)
       analysisStore.imageUrl = URL.createObjectURL(blob)
     })


### PR DESCRIPTION
This branch originally started to fix a bug where the analysis image unloads on histogram load. The source of the bug is still not known but while investigating possible causes I built up a series of improvements and fixes. Since they're a lot It's better to just split this into its own branch and start fresh on a new one to continue hunting the bug.

`drawImageWorker.js`
- further variable optimizations to reduce object access

`ImageViewer.js`
- removed unneeded check, by definition of a vue watcher it only triggers on a new value that doesn't equal the old value
- doesn't update imageOverlay if new image same as current src (also may be redundant)
- more explicit else condition

`HistogramSlider.js`
- improved gradient draw from O(n) to O(1)
- fixed bug where last bin would be out of bounds
- Jon I'm getting rid of the thumb-labels, I decided I don't like them! (pls)
- `scaleToSlider` now uses binary search instead of the two step proccess, not sure if its actually better but its more readable, this can be revered, also goes with closest index instead of either end of the array, I think this makes more sense but might be wrong

`analysis.js`
- removed conditional that blocked fallback option or largeCachedUrl

`AnalysisView.js`
- posts message all at once for simplicity
- keeps track of wether the worker is processing an image and keeps the most recent scalePoints job to send to the worker when its ready to save on processing scale points that will be overwritten anyways



