### PR TITLE
Feature/output types

### DIFF
--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -23,7 +23,7 @@ const availableOperations = ref({})
 const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedImages = ref({})
-const imagesPerRow = ref(3)
+const IMAGES_PER_ROW = 3
 
 const WIZARD_PAGES = {
   SELECT: 'select',
@@ -288,7 +288,7 @@ function selectOperation(name) {
             <image-grid
               :images="inputDescription.filter ? sortImagesByFilter(inputDescription.filter) : props.images"
               :selected-images="selectedImages[inputKey]"
-              :column-span="calculateColumnSpan(images.length, imagesPerRow)"
+              :column-span="calculateColumnSpan(images.length, IMAGES_PER_ROW)"
               :allow-selection="true"
               @select-image="selectImage(inputKey, $event)"
             />

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -51,21 +51,21 @@ const goForwardText = computed(() => {
   }
 })
 
-const disableGoForward = computed(() => {
-  if (page.value == WIZARD_PAGES.SELECT) {
-    return selectedOperation.value === ''
-  }
-  else{
-    return !isInputComplete.value
-  }
-})
-
 const wizardTitle = computed(() => {
   if (page.value == WIZARD_PAGES.SELECT) {
     return 'SELECT OPERATION'
   }
   else {
     return 'Configure ' + selectedOperation.value.name + ' Operation'
+  }
+})
+
+const disableGoForward = computed(() => {
+  if (page.value == WIZARD_PAGES.SELECT) {
+    return selectedOperation.value === ''
+  }
+  else{
+    return !isInputComplete.value
   }
 })
 

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -24,7 +24,13 @@ const selectedOperation = ref('')
 const selectedOperationInput = ref({})
 const selectedImages = ref({})
 const imagesPerRow = ref(3)
-const page = ref('select')
+
+const WIZARD_PAGES = {
+  SELECT: 'select',
+  CONFIGURE: 'configure',
+  SCALING: 'scaling'
+}
+const page = ref(WIZARD_PAGES.SELECT)
 
 onMounted(async () => {
   const url = dataSessionsUrl + 'available_operations/'
@@ -59,11 +65,11 @@ function selectOperation(name) {
 }
 
 function goBack() {
-  if (page.value == 'select') {
+  if (page.value == WIZARD_PAGES.SELECT) {
     emit('closeWizard')
   }
   else {
-    page.value = 'select'
+    page.value = WIZARD_PAGES.SELECT
   }
 }
 
@@ -82,10 +88,10 @@ const selectedOperationInputs = computed(() => {
 })
 
 const goForwardText = computed(() => {
-  if (page.value == 'select') {
-    return 'Select'
+  if (page.value == WIZARD_PAGES.SELECT) {
+    return WIZARD_PAGES.SELECT
   }
-  else if (page.value == 'configure'){
+  else if (page.value == WIZARD_PAGES.CONFIGURE){
     if (operationRequiresInputScaling.value) {
       return 'Set Image Scaling'
     }
@@ -99,7 +105,7 @@ const goForwardText = computed(() => {
 })
 
 const disableGoForward = computed(() => {
-  if (page.value == 'select') {
+  if (page.value == WIZARD_PAGES.SELECT) {
     return selectedOperation.value === ''
   }
   else{
@@ -108,7 +114,7 @@ const disableGoForward = computed(() => {
 })
 
 const wizardTitle = computed(() => {
-  if (page.value == 'select') {
+  if (page.value == WIZARD_PAGES.SELECT) {
     return 'SELECT OPERATION'
   }
   else {
@@ -149,7 +155,7 @@ function sortImagesByFilter(filters){
 }
 
 function goForward() {
-  if (page.value == 'select') {
+  if (page.value == WIZARD_PAGES.SELECT) {
     // if there are no images for a filter required by the operation, do not proceed
     for (const inputKey in selectedOperationInputs.value) {
       const inputField = selectedOperationInputs.value[inputKey]
@@ -157,11 +163,11 @@ function goForward() {
         return
       }
     }
-    page.value = 'configure'
+    page.value = WIZARD_PAGES.CONFIGURE
   }
-  else if (page.value == 'configure'){
+  else if (page.value == WIZARD_PAGES.CONFIGURE){
     if (operationRequiresInputScaling.value) {
-      page.value = 'scaling'
+      page.value = WIZARD_PAGES.SCALING
     }
     else {
       submitOperation()
@@ -220,7 +226,7 @@ function selectImage(inputKey, basename) {
         {{ wizardTitle }}
       </v-toolbar-title>
     </v-toolbar>
-    <v-card-text v-show="page == 'select'">
+    <v-card-text v-show="page == WIZARD_PAGES.SELECT">
       <v-row>
         <v-col cols="4">
           <v-list
@@ -257,7 +263,7 @@ function selectImage(inputKey, basename) {
     </v-card-text>
     <v-slide-y-reverse-transition hide-on-leave>
       <v-card-text
-        v-show="page == 'configure'"
+        v-show="page == WIZARD_PAGES.CONFIGURE"
         class="wizard-card"
       >
         <div
@@ -292,7 +298,7 @@ function selectImage(inputKey, basename) {
     </v-slide-y-reverse-transition>
     <v-slide-y-reverse-transition hide-on-leave>
       <v-card-text
-        v-show="page == 'scaling'"
+        v-show="page == WIZARD_PAGES.SCALING"
         class="wizard-card"
       >
         <div v-if="isInputComplete">

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -102,6 +102,7 @@ const operationRequiresInputScaling = computed(() => {
 })
 
 onMounted(async () => {
+  // Fetch available operations from the server
   const url = dataSessionsUrl + 'available_operations/'
   await fetchApiCall({ url: url, method: 'GET', successCallback: (data) => { availableOperations.value = data }, failCallback: handleError })
   if (Object.keys(availableOperations.value).length > 0) {
@@ -235,7 +236,7 @@ function selectOperation(name) {
             class="wizard-list"
           >
             <v-list-subheader class="wizard-subheader">
-              OPERATION
+              OPERATIONS
             </v-list-subheader>
             <v-list-item
               v-for="(name, i) in Object.keys(availableOperations)"

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -32,47 +32,6 @@ const WIZARD_PAGES = {
 }
 const page = ref(WIZARD_PAGES.SELECT)
 
-onMounted(async () => {
-  const url = dataSessionsUrl + 'available_operations/'
-  await fetchApiCall({ url: url, method: 'GET', successCallback: (data) => { availableOperations.value = data }, failCallback: handleError })
-  if (Object.keys(availableOperations.value).length > 0) {
-    selectOperation(Object.keys(availableOperations.value)[0])
-  }
-})
-
-function updateScaling(imageName, zmin, zmax) {
-  // When input image scaling is updated, we set it inside the operation input object
-  // that will then be sent to the server when we add the operation
-  selectedOperationInput.value[imageName][0].zmin = zmin
-  selectedOperationInput.value[imageName][0].zmax = zmax
-}
-
-function selectOperation(name) {
-  selectedOperation.value = name
-  selectedOperationInput.value = {}
-  selectedImages.value = {}
-  for (const [key, value] of Object.entries(selectedOperationInputs.value)) {
-    if ('default' in value) {
-      selectedOperationInput.value[key] = value.default
-    }
-    else {
-      selectedOperationInput.value[key] = null
-    }
-    if (value.type == 'file') {
-      selectedImages.value[key] = []
-    }
-  }
-}
-
-function goBack() {
-  if (page.value == WIZARD_PAGES.SELECT) {
-    emit('closeWizard')
-  }
-  else {
-    page.value = WIZARD_PAGES.SELECT
-  }
-}
-
 const selectedOperationDescription = computed(() => {
   if (availableOperations.value && selectedOperation.value) {
     return availableOperations.value[selectedOperation.value].description
@@ -142,6 +101,21 @@ const operationRequiresInputScaling = computed(() => {
   return false
 })
 
+onMounted(async () => {
+  const url = dataSessionsUrl + 'available_operations/'
+  await fetchApiCall({ url: url, method: 'GET', successCallback: (data) => { availableOperations.value = data }, failCallback: handleError })
+  if (Object.keys(availableOperations.value).length > 0) {
+    selectOperation(Object.keys(availableOperations.value)[0])
+  }
+})
+
+function updateScaling(imageName, zmin, zmax) {
+  // When input image scaling is updated, we set it inside the operation input object
+  // that will then be sent to the server when we add the operation
+  selectedOperationInput.value[imageName][0].zmin = zmin
+  selectedOperationInput.value[imageName][0].zmax = zmax
+}
+
 function sortImagesByFilter(filters){
   // Trim and lowercase all filters
   for (const filter in filters){
@@ -175,6 +149,15 @@ function goForward() {
   }
   else {
     submitOperation()
+  }
+}
+
+function goBack() {
+  if (page.value == WIZARD_PAGES.SELECT) {
+    emit('closeWizard')
+  }
+  else {
+    page.value = WIZARD_PAGES.SELECT
   }
 }
 
@@ -214,6 +197,23 @@ function selectImage(inputKey, basename) {
   else{
     alert.setAlert('warning', 'Maximum number of images selected')
     console.log('Maximum number of images selected in input', inputKey)
+  }
+}
+
+function selectOperation(name) {
+  selectedOperation.value = name
+  selectedOperationInput.value = {}
+  selectedImages.value = {}
+  for (const [key, value] of Object.entries(selectedOperationInputs.value)) {
+    if ('default' in value) {
+      selectedOperationInput.value[key] = value.default
+    }
+    else {
+      selectedOperationInput.value[key] = null
+    }
+    if (value.type == 'file') {
+      selectedImages.value[key] = []
+    }
   }
 }
 

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -184,19 +184,20 @@ function setOperationInputImages() {
 
 function selectImage(inputKey, basename) {
   const inputImages = selectedImages.value[inputKey]
-  const maxImages = selectedOperationInputs.value[inputKey].maximum
+  const input = selectedOperationInputs.value[inputKey]
 
+  // If the image is already selected, remove it from the list
   if (inputImages.includes(basename)) {
     inputImages.splice(inputImages.indexOf(basename), 1)
     setOperationInputImages()
   }
-  else if (!maxImages || inputImages.length < maxImages){
+  // If image not selected and maxImages isn't reached, add to the list
+  else if (!input.maximum || inputImages.length < input.maximum) {
     inputImages.push(basename)
     setOperationInputImages()
   }
-  else{
-    alert.setAlert('warning', 'Maximum number of images selected')
-    console.log('Maximum number of images selected in input', inputKey)
+  else {
+    alert.setAlert('warning', `${input.name} can only have ${input.maximum} image(s) selected`)
   }
 }
 

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -94,6 +94,7 @@ onMounted(async () => {
   const url = dataSessionsUrl + 'available_operations/'
   await fetchApiCall({ url: url, method: 'GET', successCallback: (data) => { availableOperations.value = data }, failCallback: handleError })
   if (Object.keys(availableOperations.value).length > 0) {
+    // Select the first operation by default
     selectOperation(Object.keys(availableOperations.value)[0])
   }
 })


### PR DESCRIPTION
Previously RGB outputs would show up as available input for operations like Medians, Subtractions, and Stacking even though they weren't compatible. In the future datalab might also output other data products like graphs, json, etc.

This PR, paired with a [PR in the backend](https://github.com/LCOGT/ptr_datalab/pull/77) address this by attaching format attributes to datalab outputs and validating input wizard description formats when creating input options.

Instead of 'file', 'fits' is now the format for a valid fits file. RGB outputs have the format of 'image'.

This PR also refactors the code in OperationWizard to follow best practices/designs
- enum page object instead of strings
- groups related functions for engineers
- more descriptive alert for max inputs
- renaming to be more clear what something is, avoid similarly named variables
- operation stored to reduce necessary lookup helpers
- Keeps track of all inputs in one object, instead of images separately that are then added in manually


https://github.com/user-attachments/assets/1d0799d4-be46-4950-8db8-008298b531a4

