### PR TITLE
Feature/rgb stack loading indicators

### DIFF
--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -298,13 +298,12 @@ function selectOperation(name) {
         v-show="page == WIZARD_PAGES.SCALING"
         class="wizard-card"
       >
-        <div v-if="isInputComplete && inputDescriptions">
-          <image-scaling-group
-            :input-description="inputDescriptions"
-            :inputs="operationInputs"
-            @update-scaling="updateScaling"
-          />
-        </div>
+        <image-scaling-group
+          v-if="isInputComplete && inputDescriptions"
+          :input-description="inputDescriptions"
+          :inputs="operationInputs"
+          @update-scaling="updateScaling"
+        />
       </v-card-text>
     </v-slide-y-reverse-transition>
 

--- a/src/components/Global/Scaling/CompositeImage.vue
+++ b/src/components/Global/Scaling/CompositeImage.vue
@@ -20,7 +20,6 @@ const props = defineProps({
 })
 
 const store = useScalingStore()
-const isLoading = ref(false) // not being used yet
 const imageCanvas = ref(null)
 var context = null
 
@@ -56,20 +55,13 @@ watch(
 <template>
   <canvas
     ref="imageCanvas"
+    class="composite-canvas elevation-8 rounded-md"
     :width="props.width"
     :height="props.height"
   />
-  <v-progress-circular
-    v-show="isLoading"
-    color="primary"
-    size="200"
-    indeterminate
-  />
 </template>
 <style scoped>
-.v-progress-circular {
-  position:fixed;
-  bottom: 40%;
-  left: 60%;
+.composite-canvas{
+  background-color: var(--card-background);
 }
 </style>

--- a/src/components/Global/Scaling/ImageScaler.vue
+++ b/src/components/Global/Scaling/ImageScaler.vue
@@ -103,7 +103,6 @@ onMounted(async () => {
 <template>
   <div class="image-scaler">
     <raw-scaled-image
-      class="mr-4"
       :max-size="props.maxSize"
       :image-data="rawData"
       :scale-points="sliderRange"
@@ -130,6 +129,7 @@ onMounted(async () => {
 <style scoped>
 .image-scaler{
   display: flex;
+  gap: 1.5rem;
 }
 .image-scale-title {
   margin-bottom: 0.5rem;

--- a/src/components/Global/Scaling/RawScaledImage.vue
+++ b/src/components/Global/Scaling/RawScaledImage.vue
@@ -40,6 +40,7 @@ var offscreen = null
 const sharedArrayBuffer = new SharedArrayBuffer(Uint8ClampedArray.BYTES_PER_ELEMENT * props.maxSize * props.maxSize)
 var sharedArray = new Uint8ClampedArray(sharedArrayBuffer)
 const worker = new Worker('drawImageWorker.js')
+const isCanvasReady = ref(false)
 
 onMounted(() => {
   // Seed the web worker with initial data including a reference to the offscreen canvas
@@ -51,6 +52,7 @@ onMounted(() => {
   if (props.compositeName != 'default') {
     worker.onmessage = () => {
       store.updateImageArray(props.compositeName, props.filter, sharedArray, props.maxSize)
+      isCanvasReady.value = true
     }
   }
 })
@@ -79,16 +81,32 @@ watch(
 
 </script>
 <template>
-  <canvas
-    ref="imageCanvas"
-    class="raw-scaled-canvas"
-    :width="props.maxSize"
-    :height="props.maxSize"
-  />
+  <div>
+    <canvas
+      ref="imageCanvas"
+      :width="props.maxSize"
+      :height="props.maxSize"
+    />
+    <v-progress-circular
+      v-if="!isCanvasReady"
+      color="var(--success)"
+      indeterminate
+      :size="80"
+      :width="10"
+    />
+  </div>
 </template>
 <style scoped>
-.raw-scaled-canvas{
+div{
+  position: relative;
+}
+canvas{
   width: 200px;
   height: 200px;
+}
+.v-progress-circular {
+  position: absolute;
+  top: 35%;
+  right: 25%;
 }
 </style>


### PR DESCRIPTION
Adds loading circles for scaling data to let the user know that scaling is loading. Before it was blank and images would pop in. For larger images this doesn't let the user know that their data is loading and they might think its broken.

Closes #163 

https://github.com/user-attachments/assets/50e1296e-d00c-46fd-8cb7-0f8f63738cae

