### PR TITLE
Rename to Explore; fix header and menu arrow

### DIFF
--- a/src/assets/css/ptr-extra.css
+++ b/src/assets/css/ptr-extra.css
@@ -89,3 +89,10 @@ p {
 	text-transform: uppercase;
 	background-color: var(--green);
 }
+
+.navbar-link:not(.is-arrowless):after {
+	border-color: var(--grey-level3);
+	inset-inline-end: 1.125em;
+	margin-top: -0.375em;
+	font-size: 50%;
+}

--- a/src/components/Global/NavBar.vue
+++ b/src/components/Global/NavBar.vue
@@ -50,7 +50,7 @@ function toggleMobileMenu () {
                 <v-icon icon="mdi-chevron-right" />
               </span></a>
               <a href="https://photonranch.lco.global" class="navbar-item observe-site-item">
-              <span>Observe</span>
+              <span>Explore</span>
               <span class="icon is-small">
                 <v-icon icon="mdi-chevron-right" />
               </span></a>
@@ -110,5 +110,11 @@ function toggleMobileMenu () {
     background-color: var(--green);
     color: var(--grey-level3);
   }
+  .navbar-link:not(.is-arrowless):after {
+        border-color: var(--grey-level3);
+        inset-inline-end: 1.125em;
+        margin-top: -0.375em;
+        font-size: 50%;
+    }
 }
 </style>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -145,7 +145,7 @@ watch(() => search.value, async () => {
 })
 
 onMounted(() => {
-  // Check so Observe@PTR can open the relevant proposal
+  // Check so Explore@PTR can open the relevant proposal
   if(route.query.proposalId){
     const proposalIndexToOpen = userDataStore.proposals.findIndex(proposal => proposal.id == route.query.proposalId)
     if(proposalIndexToOpen != -1)

--- a/vue.config.js
+++ b/vue.config.js
@@ -23,5 +23,12 @@ module.exports = defineConfig({
       })
       return definitions
     })
+  },
+  pages: {
+    index: {
+      // entry for the page
+      entry: 'src/main.js',
+      title: 'DataLab @ Photon Ranch'
+    }
   }
 })


### PR DESCRIPTION
I've changed the name of Observe to Explore. I've added a very minor fix to give a better <title> and made the menubar down arrow consistent with Explore.