### PR TITLE
Update/operation button text

### DIFF
--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -299,14 +299,12 @@ watch(
   padding: 2rem;
   margin-right: 1rem;
   border-radius: 10px;
+  max-width: 300px;
 }
 .addop_button {
-  font-size: 1rem;
-  align-content: center;
-  background-color: var(--primary-interactive);
-  font-weight: 700;
+  margin-top: 1.5rem;
+  background-color: var(--secondary-interactive);
+  font-weight: 500;
   color: var(--text);
-  margin-top: 1rem;
-  padding: 25px
 }
 </style>

--- a/src/components/DataSession/LoadBarButton.vue
+++ b/src/components/DataSession/LoadBarButton.vue
@@ -66,9 +66,11 @@ const textClass = computed(() => {
 </template>
 <style scoped>
 .loadBarButton {
+  width: 100%;
+  height: 3rem;
+  font-size: 1rem;
   position: relative;
   display: flex;
-  width: 15vw;
   justify-content: flex-start;
   overflow: hidden;
   background-color: var(--secondary-background);

--- a/src/components/DataSession/LoadBarButton.vue
+++ b/src/components/DataSession/LoadBarButton.vue
@@ -2,13 +2,22 @@
 import {computed} from 'vue'
 
 const props = defineProps({
-  progress: {
+  text: {
+    type: String,
+    required: true,
+  },
+  index: {
     type: Number,
     required: true,
   },
-  state: {
+  status: {
     type: String,
-    default: '',
+    required: false,
+    default: ''
+  },
+  progress: {
+    type: Number,
+    required: true,
   },
   error: {
     type: String,
@@ -21,8 +30,18 @@ const progressPercent = computed(() => {
   return props.error ? 100.0: props.progress * 100.0
 })
 
-const progressClass = computed(() => {
-  return props.error ? 'progress-bar error-progress-bar': 'progress-bar good-progress-bar'
+const progressBg = computed(() => {
+  return props.error ? 'progress-bar error-progress-bar' : 'progress-bar good-progress-bar'
+})
+
+const textClass = computed(() => {
+  if (props.status === 'PENDING') {
+    return 'operate-button-pending'
+  } else if (props.status === 'IN_PROGRESS') {
+    return 'operate-button-in-progress'
+  } else {
+    return ''
+  }
 })
 
 </script>
@@ -36,21 +55,26 @@ const progressClass = computed(() => {
     >
       {{ props.error }}
     </v-tooltip>
-    <slot />
+    <p :class="textClass">
+      {{ index + ". " + text }}
+    </p>
     <div
-      :class="progressClass"
+      :class="progressBg"
       :style="{ width: progressPercent + '%' }"
     />
   </v-btn>
 </template>
 <style scoped>
-.loadBarButton{
+.loadBarButton {
   position: relative;
   overflow: hidden;
   background-color: var(--secondary-background);
 }
-:slotted(p) {
+
+.loadBarButton p {
+  font-size: 1rem;
   z-index: 2;
+  position: relative;
 }
 
 .progress-bar {
@@ -58,7 +82,8 @@ const progressClass = computed(() => {
   top: 0;
   left: 0;
   height: 100%;
-  transition: 0.3s;
+  transition: width 0.3s;
+  z-index: 1;
 }
 
 .error-progress-bar {
@@ -67,23 +92,23 @@ const progressClass = computed(() => {
 
 .good-progress-bar {
   background-color: var(--success);
-  }
+}
 
 .selected .good-progress-bar {
   background-color: var(--secondary-interactive);
 }
 
-:slotted(.operate-button-in-progress) {
-  background: linear-gradient(90deg, rgb(245, 118, 0),  rgb(255,90,95), rgb(255, 0, 0));
-  background-size: 200%, auto;
+.operate-button-in-progress {
+  background: linear-gradient(90deg, rgb(245, 118, 0), rgb(255, 90, 95), rgb(255, 0, 0));
+  background-size: 200% auto;
   color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
   animation: gradient-shift 3s infinite linear;
 }
 
-:slotted(.operate-button-pending) {
-  color: var(--disabled-text)
+.operate-button-pending {
+  color: var(--disabled-text);
 }
 
 @keyframes gradient-shift {

--- a/src/components/DataSession/LoadBarButton.vue
+++ b/src/components/DataSession/LoadBarButton.vue
@@ -67,14 +67,20 @@ const textClass = computed(() => {
 <style scoped>
 .loadBarButton {
   position: relative;
+  display: flex;
+  width: 15vw;
+  justify-content: flex-start;
   overflow: hidden;
   background-color: var(--secondary-background);
 }
 
 .loadBarButton p {
-  font-size: 1rem;
-  z-index: 2;
   position: relative;
+  font-size: 0.8rem;
+  font-weight: 600;
+  z-index: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .progress-bar {
@@ -91,7 +97,7 @@ const textClass = computed(() => {
 }
 
 .good-progress-bar {
-  background-color: var(--success);
+  background-color: var(--primary-interactive);
 }
 
 .selected .good-progress-bar {
@@ -99,7 +105,7 @@ const textClass = computed(() => {
 }
 
 .operate-button-in-progress {
-  background: linear-gradient(90deg, rgb(245, 118, 0), rgb(255, 90, 95), rgb(255, 0, 0));
+  background: linear-gradient(90deg, #227d35, #43ae30, var(--success));
   background-size: 200% auto;
   color: transparent;
   background-clip: text;

--- a/src/components/DataSession/LoadBarButton.vue
+++ b/src/components/DataSession/LoadBarButton.vue
@@ -8,7 +8,8 @@ const props = defineProps({
   },
   index: {
     type: Number,
-    required: true,
+    required: false,
+    default: 0
   },
   status: {
     type: String,
@@ -56,7 +57,7 @@ const textClass = computed(() => {
       {{ props.error }}
     </v-tooltip>
     <p :class="textClass">
-      {{ index + ". " + text }}
+      {{ index ? `${index}. ${text}` : text }}
     </p>
     <div
       :class="progressBg"

--- a/src/components/DataSession/OperationGraph/OperationNode.vue
+++ b/src/components/DataSession/OperationGraph/OperationNode.vue
@@ -26,18 +26,6 @@ function selectOperation(index) {
     emit('selectOperation', index)
   }
 }
-
-function operationStateToClass(state) {
-  if (state === 'PENDING') {
-    return 'operate-button-pending'
-  }
-  else if (state === 'IN_PROGRESS') {
-    return 'operate-button-in-progress'
-  }
-  else {
-    return ''
-  }
-}
 </script>
 
 <template>
@@ -45,14 +33,12 @@ function operationStateToClass(state) {
     :class="{selected: props.id == props.selectedId}"
     class="operation_button nodrag"
     :progress="props.data.operation_progress ?? 0"
-    :state="props.data.status"
+    :status="props.data.status"
+    :index="props.data.index"
+    :text="props.data.name"
     :error="props.data.message ?? ''"
     @click="selectOperation(props.id)"
-  >
-    <p :class="operationStateToClass(props.data.status)">
-      {{ props.data.index }}: {{ props.data.name }}
-    </p>
-  </load-bar-button>
+  />
 </template>
 
 <style scoped>

--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -55,22 +55,9 @@ function itemDeleted(deletedIds) {
   emit('operationWasDeleted', deletedIds)
 }
 
-function operationStateToClass(operation) {
-  if (operation.status === 'PENDING') {
-    return 'operate-button-pending'
-  }
-  else if (operation.status === 'IN_PROGRESS') {
-    return 'operate-button-in-progress'
-  }
-  else {
-    return ''
-  }
-}
-
-
 </script>
 <template>
-  <h3 class="operations">
+  <h3 class="operations-title">
     OPERATIONS
     <v-btn
       variant="plain"
@@ -93,12 +80,11 @@ function operationStateToClass(operation) {
       :progress="operation.operation_progress ?? 0"
       :state="operation.state"
       :error="operation.message ?? ''"
+      :index="operation.index"
+      :text="operation.name"
+      :status="operation.status"
       @click="selectOperation(operation.id)"
-    >
-      <p :class="operationStateToClass(operation)">
-        {{ operation.index }}: {{ operation.name }}
-      </p>
-    </load-bar-button>
+    />
     <v-slide-x-transition hide-on-leave>
       <v-btn
         v-if="operation.id == props.selectedOperation"
@@ -118,55 +104,13 @@ function operationStateToClass(operation) {
 </template>
 
 <style scoped>
-.operations {
+.operations-title {
+  font-size: 1.5rem;
   color: var(--text);
-  letter-spacing: 0.05rem;
-  font-size: 2rem;
-}
-
-.operation{
-  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 .operation_button {
-  width: 12rem;
-  height: 3rem;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text);
-}
-
-@media (max-width: 1200px) {
-  .operations {
-    font-size: 1.3rem;
-  }
-
-  .addop_button {
-    font-size: 1rem;
-    height: 5vh;
-  }
-
-  .operation_button {
-    width: 13vw;
-    height: 4.5vh;
-    font-size: 0.8rem;
-  }
-}
-
-@media (max-width: 900px) {
-  .operations {
-    font-size: 1.2rem;
-  }
-
-  .addop_button {
-    font-size: 0.9rem;
-    height: 4vh;
-  }
-
-  .operation_button {
-    width: 15vw;
-    height: 3vh;
-    font-size: 0.7rem;
-  }
+  width: 15vw;
 }
 </style>

--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -111,6 +111,7 @@ function itemDeleted(deletedIds) {
   margin-bottom: 1.5rem;
 }
 .delete-operation-button{
+  margin-top: 0.5rem;
   justify-content: flex-start;
 }
 </style>

--- a/src/components/DataSession/OperationPipeline.vue
+++ b/src/components/DataSession/OperationPipeline.vue
@@ -71,12 +71,10 @@ function itemDeleted(deletedIds) {
   <v-row
     v-for="operation in operations"
     :key="operation.id"
-    justify="center"
     class="operation mb-2"
   >
     <load-bar-button
       :class="{selected: operation.id == props.selectedOperation}"
-      class="operation_button"
       :progress="operation.operation_progress ?? 0"
       :state="operation.state"
       :error="operation.message ?? ''"
@@ -88,8 +86,11 @@ function itemDeleted(deletedIds) {
     <v-slide-x-transition hide-on-leave>
       <v-btn
         v-if="operation.id == props.selectedOperation"
-        variant="plain"
-        icon="mdi-close"
+        class="delete-operation-button"
+        variant="text"
+        size="small"
+        prepend-icon="mdi-trash-can"
+        text="Delete"
         color="var(--cancel)"
         @click="openDeleteOperationDialog(operation)"
       />
@@ -107,10 +108,9 @@ function itemDeleted(deletedIds) {
 .operations-title {
   font-size: 1.5rem;
   color: var(--text);
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
-
-.operation_button {
-  width: 15vw;
+.delete-operation-button{
+  justify-content: flex-start;
 }
 </style>

--- a/src/views/DataSessionsView.vue
+++ b/src/views/DataSessionsView.vue
@@ -5,9 +5,7 @@ import { useUserDataStore } from '@/stores/userData'
 import { fetchApiCall, handleError } from '../utils/api'
 import DataSession from '@/components/DataSession/DataSession.vue'
 import DeleteSessionDialog from '@/components/DataSession/DeleteSessionDialog.vue'
-import { useRouter } from 'vue-router'
 
-const router = useRouter()
 const configurationStore = useConfigurationStore()
 const userDataStore = useUserDataStore()
 const dataSessions = ref([])
@@ -78,16 +76,11 @@ function tabActive(index) {
           variant="plain"
           size="small"
           icon="mdi-close"
+          color="var(--cancel)"
           class="tab_button"
           @click="openDeleteDialog(ds.id)"
         />
       </v-tab>
-      <v-btn
-        variant="plain"
-        icon="mdi-plus-box"
-        class="tab_button"
-        @click="router.push({ name: 'ProjectView' })"
-      />
     </v-tabs>
     <v-window v-model="userDataStore.activeSessionId">
       <v-window-item


### PR DESCRIPTION
- Text always fits on the button no matter how small the screen gets. 
- Other styling changes
- Use props instead of slot
- use dynamic sizing instead of screen width
- Move delete button to pop out under operation on left to be more reachable on tablet

Closes #189 

![Screenshot 2025-04-15 at 4 35 13 PM](https://github.com/user-attachments/assets/b41c1156-0560-4679-b737-3e9569aa1cf1)


https://github.com/user-attachments/assets/079746bf-c95a-4a9e-b5c4-078343647433


