### PR TITLE
Fix/leaflet rawdata unload

### DIFF
--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -18,6 +18,7 @@ onmessage = function(job) {
     context = canvas.getContext('2d')
     outputImage = new ImageData(payload.width, payload.height)
 
+    // Used for RGB stack, not used in grayscale scaling
     if(payload.sharedArrayBuffer){
       sharedArrayBuffer = payload.sharedArrayBuffer
       sharedArray = new Uint8ClampedArray(sharedArrayBuffer) 
@@ -76,7 +77,7 @@ async function processScalePoints(scalePoints) {
     outputImageData[j + 3] = 255
   }
 
-  context.putImageData(outputImage, 0, 0)
+  await context.putImageData(outputImage, 0, 0)
   const blob = await canvas.convertToBlob()
   postMessage({ blob: blob})
 }

--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -1,4 +1,4 @@
-var context, imageData, sharedArrayBuffer, sharedArray, gammaTable, outputImage, scalePointMessage
+var canvas, context, imageData, sharedArrayBuffer, sharedArray, gammaTable, outputImage, scalePointMessage
 let hasImageData = false
 let hasCanvas = false
  
@@ -14,7 +14,8 @@ onmessage = function(job) {
 
   if (payload.canvas) {
     // Init worker with the canvas, width, height, imageData, and sharedArrayBuffer
-    context = payload.canvas.getContext('2d')
+    canvas = payload.canvas
+    context = canvas.getContext('2d')
     outputImage = new ImageData(payload.width, payload.height)
 
     if(payload.sharedArrayBuffer){
@@ -45,13 +46,13 @@ onmessage = function(job) {
   tryProcessScalePoints()
 }
 
-function tryProcessScalePoints() {
+async function tryProcessScalePoints() {
   if(hasImageData && hasCanvas && scalePointMessage.length) {
-    processScalePoints(scalePointMessage)
+    await processScalePoints(scalePointMessage)
   }
 }
 
-function processScalePoints(scalePoints) {
+async function processScalePoints(scalePoints) {
   // Re-compute the image and redraw it to the canvas
   const len = imageData.data.length
   const low16Bit = parseInt(scalePoints[0])
@@ -76,5 +77,6 @@ function processScalePoints(scalePoints) {
   }
 
   context.putImageData(outputImage, 0, 0)
-  postMessage({'updateSharedArray': true})
+  const blob = await canvas.convertToBlob()
+  postMessage({ blob: blob})
 }

--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -78,6 +78,13 @@ async function processScalePoints(scalePoints) {
   }
 
   await context.putImageData(outputImage, 0, 0)
-  const blob = await canvas.convertToBlob()
-  postMessage({ blob: blob})
+
+  // RGB uses sharedArrayBuffer, grayscale creates a blob
+  if(!sharedArrayBuffer){
+    const blob = await canvas.convertToBlob()
+    postMessage({ blob: blob})
+  }
+  else {
+    postMessage({'updateSharedArray': true})
+  }
 }

--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -31,38 +31,33 @@ onmessage = function(job) {
     }
 
     hasCanvas = true
-    tryProcessScalePoints()
   }
 
   if (payload.imageData) {
     imageData = payload.imageData
     hasImageData = true
-    tryProcessScalePoints()
   }
 
   if (payload.scalePoints) {
     scalePointMessage = payload.scalePoints
-    tryProcessScalePoints()
   }
+
+  tryProcessScalePoints()
 }
 
 function tryProcessScalePoints() {
-  if(hasImageData && hasCanvas && scalePointMessage) {
-    // optimization to process only most recent queued scale
+  if(hasImageData && hasCanvas && scalePointMessage.length) {
     processScalePoints(scalePointMessage)
-    scalePointMessage = null
   }
 }
 
 function processScalePoints(scalePoints) {
   // Re-compute the image and redraw it to the canvas
+  const len = imageData.data.length
   const low16Bit = parseInt(scalePoints[0])
   const high16Bit = parseInt(scalePoints[1])
-  const scale = 255 / (high16Bit - low16Bit)
-  const len = imageData.data.length
-
-  const outputImageData = outputImage.data
   const srcData = imageData.data
+  const scale = 255 / (high16Bit - low16Bit)
 
   for (let i = 0; i < len; i++) {
     const clippedValue = Math.max(low16Bit, Math.min(high16Bit, srcData[i]))
@@ -71,12 +66,15 @@ function processScalePoints(scalePoints) {
 
     if(sharedArray) sharedArray[i] = gammaCorrected
 
+    const outputImageData = outputImage.data
     const j = i * 4
+
     outputImageData[j] = gammaCorrected
     outputImageData[j + 1] = gammaCorrected
     outputImageData[j + 2] = gammaCorrected
     outputImageData[j + 3] = 255
   }
+
   context.putImageData(outputImage, 0, 0)
   postMessage({'updateSharedArray': true})
 }

--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -47,9 +47,9 @@ onmessage = function(job) {
   tryProcessScalePoints()
 }
 
-async function tryProcessScalePoints() {
+function tryProcessScalePoints() {
   if(hasImageData && hasCanvas && scalePointMessage.length) {
-    await processScalePoints(scalePointMessage)
+    processScalePoints(scalePointMessage)
   }
 }
 
@@ -77,7 +77,7 @@ async function processScalePoints(scalePoints) {
     outputImageData[j + 3] = 255
   }
 
-  await context.putImageData(outputImage, 0, 0)
+  context.putImageData(outputImage, 0, 0)
 
   // RGB uses sharedArrayBuffer, grayscale creates a blob
   if(!sharedArrayBuffer){

--- a/src/components/Analysis/ImageDownloadMenu.vue
+++ b/src/components/Analysis/ImageDownloadMenu.vue
@@ -77,7 +77,7 @@ function downloadFile(file, filename, fileType='file'){
       key="4"
       class="file-download"
       text="Scaled .JPG"
-      @click="$emit('analysisAction', 'get-jpg', {'basename': props.imageName, 'zmin': analysisStore.scaledZmin, 'zmax': analysisStore.scaledZmax}, downloadBase64File)"
+      @click="$emit('analysisAction', 'get-jpg', {'basename': props.imageName, 'zmin': analysisStore.zmin, 'zmax': analysisStore.zmax}, downloadBase64File)"
     />
   </v-speed-dial>
 </template>

--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -64,7 +64,6 @@ async function initImageOverlay(imgSrc) {
 }
 
 function leafletSetup(){
-  console.log('leafletSetup creating map, controls, listeners')
   // Create leaflet map (here referred to as image)
   imageMap = L.map(leafletDiv.value, {
     maxZoom: 5,

--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -35,7 +35,7 @@ onMounted(() => {
 
 watch(() => props.catalog, () => createCatalogLayer())
 
-watch(() => analysisStore.imageUrl, async (newImageUrl) => {
+watch(() => analysisStore.imageUrl, (newImageUrl) => {
   imageOverlay ? imageOverlay.setUrl(newImageUrl) : initImageOverlay(newImageUrl)
 })
 

--- a/src/components/Global/FilterBadge.vue
+++ b/src/components/Global/FilterBadge.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 </script>
 <template>
   <p
-    class="filter-badge"
+    class="filter-badge rounded d-flex pa-2 justify-center align-center"
     :style="{ backgroundColor: filterToColor(props.filter) }"
   >
     {{ props.filter }}
@@ -19,12 +19,10 @@ const props = defineProps({
 </template>
 <style scoped>
 .filter-badge {
-  border-radius: 10px;
   color: var(--text);
-  padding: 6px 10px;
-  display: inline-block;
   user-select: none;
   font-size: smaller;
   font-weight: bolder;
+  max-width: 2.2rem;
 }
 </style>

--- a/src/components/Global/Scaling/HistogramSlider.vue
+++ b/src/components/Global/Scaling/HistogramSlider.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 
 // This component draws a sparkline histogram with range slider controls on top of it.
 // It has two coordinate systems - sliderRange which is a linear system of bins for the
@@ -44,6 +44,8 @@ const emit = defineEmits(['updateScaling'])
 
 const scaleRange = ref([props.bins[0], props.bins[props.bins.length-1]])
 const sliderRange = ref([0, props.bins.length-1])
+const initZmin = ref(props.zMin)
+const initZmax = ref(props.zMax)
 const backgroundColor = 'var(--text)'
 
 const gradient = computed(() => {
@@ -58,10 +60,6 @@ const gradient = computed(() => {
 
   return gradientArray
 })
-
-function sliderToBinValue(sliderValue) {
-  return props.bins[sliderValue] ?? console.error('Slider value out of bounds')
-}
 
 /**
  * Maps a scale value (zmin/zmax) to a slider value (0 to bins.length-1)
@@ -83,6 +81,10 @@ function scaleToSliderValue(scaleValue) {
 
   // Return the closest index
   return Math.abs(bins[left] - scaleValue) < Math.abs(bins[right] - scaleValue) ? left : right
+}
+
+function sliderToBinValue(sliderValue) {
+  return props.bins[sliderValue] ?? console.error('Slider value out of bounds')
 }
 
 function updateScaleRange() {
@@ -110,16 +112,14 @@ function updateUpperScale(value) {
 
 function zScaleImage() {
   // This is called to reset the ranges to the zMin/zMax
-  scaleRange.value = [props.zMin, props.zMax]
-  sliderRange.value = [scaleToSliderValue(props.zMin), scaleToSliderValue(props.zMax)]
+  scaleRange.value = [initZmin.value, initZmax.value]
+  sliderRange.value = [scaleToSliderValue(initZmin.value), scaleToSliderValue(initZmax.value)]
   emit('updateScaling', ...scaleRange.value)
 }
 
-watch(
-  () => props.zMax, () => {
-    zScaleImage()
-  }, { immediate: true }
-)
+onMounted(() => {
+  zScaleImage()
+})
 
 </script>
 <template>

--- a/src/components/Global/Scaling/HistogramSlider.vue
+++ b/src/components/Global/Scaling/HistogramSlider.vue
@@ -65,6 +65,13 @@ onMounted(() => {
   zScaleImage()
 })
 
+// In case the zMax or zMin change, update the initZmax/Zmin
+watch([() => props.zMax, () => props.zMin], () => {
+  initZmax.value = props.zMax
+  initZmin.value = props.zMin
+  zScaleImage()
+})
+
 watch(() => scaleRange.value, (newValue) => {
   // This is called when the scale range is changed
   sliderRange.value[0] = scaleToSliderValue(newValue[0])

--- a/src/components/Global/Scaling/HistogramSlider.vue
+++ b/src/components/Global/Scaling/HistogramSlider.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, watch, computed, onMounted } from 'vue'
 
 // This component draws a sparkline histogram with range slider controls on top of it.
 // It has two coordinate systems - sliderRange which is a linear system of bins for the
@@ -61,6 +61,17 @@ const gradient = computed(() => {
   return gradientArray
 })
 
+onMounted(() => {
+  zScaleImage()
+})
+
+watch(() => scaleRange.value, (newValue) => {
+  // This is called when the scale range is changed
+  sliderRange.value[0] = scaleToSliderValue(newValue[0])
+  sliderRange.value[1] = scaleToSliderValue(newValue[1])
+  emit('updateScaling', ...scaleRange.value)
+}, { deep: true })
+
 /**
  * Maps a scale value (zmin/zmax) to a slider value (0 to bins.length-1)
  * So when a scale value is changed with the number fields,
@@ -94,32 +105,12 @@ function updateScaleRange() {
   emit('updateScaling', ...scaleRange.value)
 }
 
-function updateLowerScale(value) {
-  // This is called when a change is made on the lower point number control
-  value = Number(value)
-  scaleRange.value[0] = value
-  sliderRange.value[0] = scaleToSliderValue(value)
-  emit('updateScaling', ...scaleRange.value)
-}
-
-function updateUpperScale(value) {
-  // This is called when a change is made on the upper point number control
-  value = Number(value)
-  scaleRange.value[1] = value
-  sliderRange.value[1] = scaleToSliderValue(value)
-  emit('updateScaling', ...scaleRange.value)
-}
-
 function zScaleImage() {
   // This is called to reset the ranges to the zMin/zMax
   scaleRange.value = [initZmin.value, initZmax.value]
   sliderRange.value = [scaleToSliderValue(initZmin.value), scaleToSliderValue(initZmax.value)]
   emit('updateScaling', ...scaleRange.value)
 }
-
-onMounted(() => {
-  zScaleImage()
-})
 
 </script>
 <template>
@@ -135,7 +126,6 @@ onMounted(() => {
         bg-color="var(--card-background)"
         hide-spin-buttons
         hide-details
-        @update:model-value="updateLowerScale"
       />
     </v-col>
     <v-col>
@@ -149,7 +139,6 @@ onMounted(() => {
         bg-color="var(--card-background)"
         hide-spin-buttons
         hide-details
-        @update:model-value="updateUpperScale"
       />
     </v-col>
     <v-col>

--- a/src/components/Global/Scaling/ImageScaler.vue
+++ b/src/components/Global/Scaling/ImageScaler.vue
@@ -2,7 +2,6 @@
 import { ref, computed, onMounted } from 'vue'
 import { useConfigurationStore } from '@/stores/configuration'
 import { fetchApiCall } from '@/utils/api'
-import { filterToColor } from '@/utils/common'
 import RawScaledImage from './RawScaledImage.vue'
 import HistogramSlider from './HistogramSlider.vue'
 
@@ -115,7 +114,7 @@ onMounted(async () => {
         {{ filterName }} Channel
       </h3>
       <histogram-slider
-        :selected-color="filterToColor(props.image.filter)"
+        :selected-color="filterName.trim().toLowerCase()"
         :histogram="histogram"
         :bins="bins"
         :max-value="maxPixelValue"

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -11,8 +11,6 @@ export const useAnalysisStore = defineStore('analysis', {
     rawData: null, // raw data from the analysis/raw_data endpoint
     zmin: null, // minimum z value of the raw data
     zmax: null, // maximum z value of the raw data
-    scaledZmin: null, // minimum z value of the scaled data
-    scaledZmax: null, // maximum z value of the scaled data
     imageUrl: '', // URL of the image to display
     imageWidth: null, // width of the image in pixels
     imageHeight: null, // height of the image in pixels

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -28,14 +28,14 @@ const filterToColor = (filter) => {
 
 function siteIDToName(siteID) {
   const siteIDMap = {
-    'COJ': 'Siding Spring @ New South Wales',
-    'CPT': 'South African Astronomical @ Cape Town',
-    'TFN': 'Teide @ Tenerife',
-    'LSC': 'Cerro Tololo Inter-American @ Chile',
-    'ELP': 'McDonald @ University of Texas',
-    'OGG': 'Haleakala @ Maui',
-    'TLV': 'Wise @ Tel Aviv University',
-    'NGQ': 'Ali @ Tibet',
+    'COJ': 'COJ @ Siding Spring',
+    'CPT': 'CPT @ South African Astronomical',
+    'TFN': 'TFN @ Teide',
+    'LSC': 'LSC @ Cerro Tololo Inter-American',
+    'ELP': 'ELP @ McDonald',
+    'OGG': 'OGG @ Haleakala',
+    'TLV': 'TLV @ Wise',
+    'NGQ': 'NGQ @ Ali',
   }
 
   return siteIDMap[siteID?.toUpperCase()] || siteID

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -237,11 +237,11 @@ function updateScaling(min, max){
         </v-expand-transition>
         <v-expand-transition>
           <v-sheet
-            v-if="analysisStore.imageScaleReady"
             class="side-panel-item"
             rounded
           >
             <histogram-slider
+              v-if="analysisStore.imageScaleReady"
               :histogram="analysisStore.histogram"
               :bins="analysisStore.bins"
               :max-value="analysisStore.maxPixelValue"
@@ -249,20 +249,37 @@ function updateScaling(min, max){
               :z-max="Number(analysisStore.zmax)"
               @update-scaling="updateScaling"
             />
+            <div
+              v-else
+              class="d-flex ga-4 align-center justify-center"
+            >
+              <p class="d-block">
+                Histogram
+              </p>
+              <v-progress-linear
+                color="var(--success)"
+                :height="6"
+                indeterminate
+                rounded
+              />
+            </div>
           </v-sheet>
         </v-expand-transition>
-        <v-sheet
-          class="side-panel-item line-plot-sheet"
-          rounded
-        >
-          <line-plot
-            :y-axis-data="lineProfile"
-            :x-axis-length="lineProfileLength"
-            :start-coords="startCoords"
-            :end-coords="endCoords"
-            :position-angle="positionAngle"
-          />
-        </v-sheet>
+        <v-expand-transition>
+          <v-sheet
+            v-show="lineProfile.length"
+            class="side-panel-item line-plot-sheet"
+            rounded
+          >
+            <line-plot
+              :y-axis-data="lineProfile"
+              :x-axis-length="lineProfileLength"
+              :start-coords="startCoords"
+              :end-coords="endCoords"
+              :position-angle="positionAngle"
+            />
+          </v-sheet>
+        </v-expand-transition>
       </div>
     </div>
   </v-sheet>

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -139,10 +139,7 @@ async function instantiateScalerWorker(){
   // Image creation for leaflet map, clean up the old image url
   imgWorker.onmessage = (event) => {
     imgWorkerProcessing = false
-    if(event.data.blob){
-      URL.revokeObjectURL(analysisStore.imageUrl)
-      analysisStore.imageUrl = URL.createObjectURL(event.data.blob)
-    }
+    analysisStore.imageUrl = URL.createObjectURL(event.data.blob)
   }
 }
 

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -139,7 +139,7 @@ async function instantiateScalerWorker(){
   // Image creation for leaflet map, clean up the old image url
   imgWorker.onmessage = () => {
     imgWorkerProcessing = false
-    updateScaling()
+    updateScaling(analysisStore.zmin, analysisStore.zmax) // This inits on first load but probably shouldn't be here
     imgScalingCanvas.toBlob((blob) => {
       if (analysisStore.imageUrl) URL.revokeObjectURL(analysisStore.imageUrl)
       analysisStore.imageUrl = URL.createObjectURL(blob)
@@ -149,8 +149,8 @@ async function instantiateScalerWorker(){
 
 function updateScaling(min, max){
   if(min && max){
-    analysisStore.scaledZmin = min
-    analysisStore.scaledZmax = max
+    analysisStore.zmin = min
+    analysisStore.zmax = max
     imgWorkerNextScale = [min, max]
   }
 

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -136,12 +136,12 @@ async function instantiateScalerWorker(){
   }, [offscreen])
 
   // Image creation for leaflet map, clean up the old image url
-  imgWorker.onmessage = () => {
+  imgWorker.onmessage = (event) => {
     imgWorkerProcessing = false
-    imgScalingCanvas.toBlob((blob) => {
-      if (analysisStore.imageUrl) URL.revokeObjectURL(analysisStore.imageUrl)
-      analysisStore.imageUrl = URL.createObjectURL(blob)
-    })
+    if(event.data.blob){
+      URL.revokeObjectURL(analysisStore.imageUrl)
+      analysisStore.imageUrl = URL.createObjectURL(event.data.blob)
+    }
   }
 }
 

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -249,8 +249,8 @@ function updateScaling(min, max){
               :histogram="analysisStore.histogram"
               :bins="analysisStore.bins"
               :max-value="analysisStore.maxPixelValue"
-              :z-min="analysisStore.zmin"
-              :z-max="analysisStore.zmax"
+              :z-min="Number(analysisStore.zmin)"
+              :z-max="Number(analysisStore.zmax)"
               @update-scaling="updateScaling"
             />
           </v-sheet>

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -147,11 +147,7 @@ async function instantiateScalerWorker(){
 }
 
 function updateScaling(min, max){
-  if(min && max){
-    analysisStore.zmin = min
-    analysisStore.zmax = max
-    imgWorkerNextScale = [min, max]
-  }
+  imgWorkerNextScale = [min, max]
 
   if (imgWorkerNextScale && !imgWorkerProcessing){
     imgWorkerProcessing = true

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -39,6 +39,7 @@ const headerDialog = ref(false)
 const headerData = ref({})
 const imgWorker = new Worker('drawImageWorker.js')
 let imgWorkerProcessing = false
+let imgWorkerNextScale = null
 
 const filteredCatalog = computed(() => {
   if(catalogToggle.value){
@@ -149,11 +150,13 @@ function updateScaling(min, max){
   if(min && max){
     analysisStore.zmin = min
     analysisStore.zmax = max
+    imgWorkerNextScale = [min, max]
   }
 
-  if (!imgWorkerProcessing){
+  if (imgWorkerNextScale && !imgWorkerProcessing){
     imgWorkerProcessing = true
-    imgWorker.postMessage({scalePoints: [analysisStore.zmin, analysisStore.zmax]})
+    imgWorker.postMessage({scalePoints: [...imgWorkerNextScale]})
+    imgWorkerNextScale = null
   }
 }
 

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -194,7 +194,7 @@ function updateScaling(min, max){
       <div class="side-panel-container">
         <v-sheet
           v-if="image.site_id || image.telescope_id || image.instrument_id || image.observation_date"
-          class="side-panel-item pa-4"
+          class="side-panel-item pa-4 d-flex ga-6 justify-space-evenly"
           rounded
         >
           <p v-if="image.site_id">

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -39,7 +39,6 @@ const headerDialog = ref(false)
 const headerData = ref({})
 const imgWorker = new Worker('drawImageWorker.js')
 let imgWorkerProcessing = false
-let imgWorkerNextScale = null
 
 const filteredCatalog = computed(() => {
   if(catalogToggle.value){
@@ -139,7 +138,6 @@ async function instantiateScalerWorker(){
   // Image creation for leaflet map, clean up the old image url
   imgWorker.onmessage = () => {
     imgWorkerProcessing = false
-    updateScaling(analysisStore.zmin, analysisStore.zmax) // This inits on first load but probably shouldn't be here
     imgScalingCanvas.toBlob((blob) => {
       if (analysisStore.imageUrl) URL.revokeObjectURL(analysisStore.imageUrl)
       analysisStore.imageUrl = URL.createObjectURL(blob)
@@ -151,13 +149,11 @@ function updateScaling(min, max){
   if(min && max){
     analysisStore.zmin = min
     analysisStore.zmax = max
-    imgWorkerNextScale = [min, max]
   }
 
-  if (imgWorkerNextScale && !imgWorkerProcessing){
+  if (!imgWorkerProcessing){
     imgWorkerProcessing = true
-    imgWorker.postMessage({scalePoints: [...imgWorkerNextScale]})
-    imgWorkerNextScale = null
+    imgWorker.postMessage({scalePoints: [analysisStore.zmin, analysisStore.zmax]})
   }
 }
 


### PR DESCRIPTION
Bug: On the intial load of the raw-data for zscaling the image the image map would go blank. The user would have to adjust the slider or click zscale and then the image would show up.

Cause: There was a race condition with the offscreen canvas and the blob creation for the first run. After it "warmed up" the blob could be created from the canvas. But for the first time the canvas was wrote to it wouldn't finish before the blob was created resulting in a blank image. Since we clean up the previous image with revokeObjectUrl it didn't have a fallback to display,.

Fix: Moved blob creation into the worker so that it always will run after the worker has finished drawing the scaled image to the canvas.

Now the image zscales when the raw-data loads and doesn't create a blank map.

Leaflet map no longer goes blank after zscale data loaded

Closes #188 
Closes #180 

https://github.com/user-attachments/assets/3387bef5-34e4-4af8-8ce1-1e10e3bc9d21

Still working with RGB scaling

![Screenshot 2025-04-21 at 11 52 31 AM](https://github.com/user-attachments/assets/1e40abe0-f531-4956-bf6e-da92578bc4d9)