### PR TITLE
Fix/histogram loading

### DIFF
--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -48,7 +48,7 @@ onmessage = function(job) {
 }
 
 function tryProcessScalePoints() {
-  if(hasImageData && hasCanvas && scalePointMessage.length) {
+  if(hasImageData && hasCanvas && scalePointMessage) {
     processScalePoints(scalePointMessage)
   }
 }

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -16,28 +16,28 @@ export const useAnalysisStore = defineStore('analysis', {
     imageHeight: null, // height of the image in pixels
   }),
   getters: {
-    imageScaleReady: (state) => state.imageWidth && state.imageHeight && state.rawData && state.zmin && state.zmax,
+    imageScaleReady: (state) => state.imageWidth && state.imageHeight && state.rawData && state.zmin != null && state.zmax != null,
     histogram: (state) => { return state.rawData.histogram },
     bins: (state) => { return state.rawData.bins },
     maxPixelValue: (state) => { Math.pow(2, state.rawData.bitdepth) - 1 },
   },
   actions: {
     async loadScaleData() {
+      if(!this.image){
+        console.error('No image object provided')
+        return
+      }
+
       if(!this.imageScaleReady){
-        await this.loadImageDimensions()
+        await this.loadImageDimensions(this.imageUrl || this.image.largeCachedUrl)
         await this.loadRawData()
       }
     },
     // Load image dimensions
-    loadImageDimensions() {
-      // Check if image dimensions are already loaded
-      if (this.imageWidth && this.imageHeight) {
-        return
-      }
-
-      const url = this.imageUrl || this.image.largeCachedUrl
+    loadImageDimensions(url) {
       const img = new Image()
       img.src = url
+
       return new Promise((resolve) => {
         img.onload = () => {
           this.imageWidth = img.width
@@ -55,11 +55,6 @@ export const useAnalysisStore = defineStore('analysis', {
       const configStore = useConfigurationStore()
       const datalabApiBaseUrl = configStore.datalabApiBaseUrl
       const url = datalabApiBaseUrl + 'analysis/raw-data/'
-
-      if(!this.image){
-        console.error('No image object provided')
-        return
-      }
 
       const requestBody = {
         'basename': this.image.basename,

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -14,6 +14,7 @@ export const useAnalysisStore = defineStore('analysis', {
     imageUrl: '', // URL of the image to display
     imageWidth: null, // width of the image in pixels
     imageHeight: null, // height of the image in pixels
+    imageScaleLoading: false, // flag to indicate if the image scale is loading
   }),
   getters: {
     imageScaleReady: (state) => state.imageWidth && state.imageHeight && state.rawData && state.zmin != null && state.zmax != null,
@@ -23,6 +24,8 @@ export const useAnalysisStore = defineStore('analysis', {
   },
   actions: {
     async loadScaleData() {
+      this.imageScaleLoading = true
+
       if(!this.image){
         console.error('No image object provided')
         return
@@ -32,6 +35,8 @@ export const useAnalysisStore = defineStore('analysis', {
         await this.loadImageDimensions(this.imageUrl || this.image.largeCachedUrl)
         await this.loadRawData()
       }
+
+      this.imageScaleLoading = false
     },
     // Load image dimensions
     loadImageDimensions(url) {

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -249,7 +249,7 @@ function updateScaling(min, max){
               @update-scaling="updateScaling"
             />
             <div
-              v-else
+              v-else-if="analysisStore.imageScaleLoading"
               class="d-flex ga-4 align-center justify-center"
             >
               <p class="d-block">


### PR DESCRIPTION
Noticed a bug when testing that zmin could be 0, but then the imageScaleReady flag would be set to false, causing the raw data to successfully load but the scaling to not enable. 

- Refactored to reduce function complexity 
- added a new flag to watch loading state so that failed histogram loads wouldn't show the loading bar going forever
- check for scalepoints existence vs length to avoid confusing errors