### PR TITLE
Fix image processing dimensions and validate scale points in worker

### DIFF
--- a/public/drawImageWorker.js
+++ b/public/drawImageWorker.js
@@ -16,7 +16,7 @@ onmessage = function(job) {
     // Init worker with the canvas, width, height, imageData, and sharedArrayBuffer
     canvas = payload.canvas
     context = canvas.getContext('2d')
-    outputImage = new ImageData(payload.width, payload.height)
+    outputImage = new ImageData(payload.canvas.width, payload.canvas.height)
 
     // Used for RGB stack, not used in grayscale scaling
     if(payload.sharedArrayBuffer){
@@ -48,7 +48,7 @@ onmessage = function(job) {
 }
 
 function tryProcessScalePoints() {
-  if(hasImageData && hasCanvas && scalePointMessage) {
+  if(hasImageData && hasCanvas && Array.isArray(scalePointMessage)) {
     processScalePoints(scalePointMessage)
   }
 }

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -3,6 +3,8 @@ import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
 import { fetchApiCall } from '@/utils/api.js'
 
+const MAX_IMAGE_DIMENSION = 1024 // Maximum dimension for performance
+
 /**
  * This store manages the images and analysis results displayed on the analysis page.
  */
@@ -57,8 +59,8 @@ export const useAnalysisStore = defineStore('analysis', {
 
       return new Promise((resolve) => {
         img.onload = () => {
-          this.imageWidth = img.width
-          this.imageHeight = img.height
+          this.imageWidth = Math.min(img.width, MAX_IMAGE_DIMENSION)
+          this.imageHeight = Math.min(img.height, MAX_IMAGE_DIMENSION)
           resolve()
         }
       })
@@ -76,7 +78,7 @@ export const useAnalysisStore = defineStore('analysis', {
       const requestBody = {
         'basename': this.image.basename,
         'source': this.image.source,
-        'max_size': Math.min(Math.min(this.imageWidth, this.imageHeight), 1024),
+        'max_size': Math.min(this.imageWidth, this.imageHeight),
       }
 
       await fetchApiCall({url: url, method: 'POST', body: requestBody,

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -117,8 +117,6 @@ async function instantiateScalerWorker(){
   // Post the image data to the worker
   imgWorker.postMessage({
     canvas: offscreen,
-    width: analysisStore.imageWidth,
-    height: analysisStore.imageHeight,
     imageData: structuredClone(analysisStore.rawData)
   }, [offscreen])
 


### PR DESCRIPTION
Closes #201 

Histograms were being squashed into half the image. We were calling the /raw-data/ endpoint with a max dimension of 1024 to save processing which we should do, but it wasn't being set for the size of the canvas the image worker would draw on as well.

This caused the /raw-data/ endpoint to return a 1024x1024 image while the canvas was the original size of the image (in most cases being 1500x1500). This caused the render to "squash/smush" the image because there were not enough pixels to fill the canvas fully.

This is fixed by setting the max_dimensions in the analysis store when we first load the image, so anything that uses those dimensions will have the proper sizing.

Before:
![Screenshot 2025-07-01 at 11 16 39 AM](https://github.com/user-attachments/assets/7c631563-2de1-4150-93fb-50478740ccb9)

After:
![Screenshot 2025-07-01 at 11 17 30 AM](https://github.com/user-attachments/assets/793f68bd-a6be-4d15-971f-e91860623114)

