### PR TITLE
Feature/period folding

### DIFF
--- a/src/components/Analysis/LightCurvePlot.vue
+++ b/src/components/Analysis/LightCurvePlot.vue
@@ -11,9 +11,11 @@ const CHART_PADDING = 0.5
 const DECIMAL_PLACES = 4
 
 const chartData = computed(() => {
-  const dates = analysisStore.variableStarData.magTimeSeries.map(({ julian_date }) => julian_date)
-  const magnitudes = analysisStore.variableStarData.magTimeSeries.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
-  const errors = analysisStore.variableStarData.magTimeSeries.map(({ mag, magerr }) => {
+  const magTimeSeries = analysisStore.variableStarData.magTimeSeries
+
+  const dates = magTimeSeries.map(({ julian_date }) => julian_date)
+  const magnitudes = magTimeSeries.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
+  const errors = magTimeSeries.map(({ mag, magerr }) => {
     const lowerBound = (mag - magerr).toFixed(DECIMAL_PLACES)
     const upperBound = (mag + magerr).toFixed(DECIMAL_PLACES)
     return [lowerBound, upperBound]

--- a/src/components/Analysis/LightCurvePlot.vue
+++ b/src/components/Analysis/LightCurvePlot.vue
@@ -7,7 +7,7 @@ import { useAnalysisStore } from '@/stores/analysis'
 const analysisStore = useAnalysisStore()
 const lightCurveCanvas = ref(null)
 let lightCurveChart = null
-const CHART_PADDING = 0.05
+const CHART_PADDING = 0.5
 const DECIMAL_PLACES = 4
 
 const chartData = computed(() => {

--- a/src/components/Analysis/LightCurvePlot.vue
+++ b/src/components/Analysis/LightCurvePlot.vue
@@ -1,0 +1,134 @@
+<script setup>
+import Chart from 'chart.js/auto'
+import 'chartjs-adapter-luxon'
+import { ref, watch, computed } from 'vue'
+import { useAnalysisStore } from '@/stores/analysis'
+
+const analysisStore = useAnalysisStore()
+const lightCurveCanvas = ref(null)
+let lightCurveChart = null
+const CHART_PADDING = 0.05
+const DECIMAL_PLACES = 4
+
+const chartData = computed(() => {
+  const dates = analysisStore.variableStarData.magTimeSeries.map(({ julian_date }) => julian_date)
+  const magnitudes = analysisStore.variableStarData.magTimeSeries.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
+  const errors = analysisStore.variableStarData.magTimeSeries.map(({ mag, magerr }) => {
+    const lowerBound = (mag - magerr).toFixed(DECIMAL_PLACES)
+    const upperBound = (mag + magerr).toFixed(DECIMAL_PLACES)
+    return [lowerBound, upperBound]
+  })
+
+  return {
+    dates: dates,
+    magnitudes: magnitudes,
+    errors: errors,
+    chartMin: Math.min(...magnitudes) - CHART_PADDING,
+    chartMax: Math.max(...magnitudes) + CHART_PADDING
+  }
+})
+
+watch(() => analysisStore.variableStarData, () => {
+  lightCurveChart && analysisStore.variableStarData.magTimeSeries ? updateChart() : createChart()
+}, { deep: true})
+
+function updateChart() {
+  // Updates the chart when user runs flux analysis again
+  const { dates, magnitudes, errors, chartMin, chartMax } = chartData.value
+  lightCurveChart.data.labels = dates
+  lightCurveChart.data.datasets[0].data = magnitudes
+  lightCurveChart.data.datasets[1].data = errors
+  lightCurveChart.options.scales.y.min = chartMin
+  lightCurveChart.options.scales.y.max = chartMax
+  lightCurveChart.update()
+}
+
+function createChart() {
+  // chartJs can't use css vars as strings, so we need to get the actual value
+  var style = getComputedStyle(document.body)
+  const text = style.getPropertyValue('--text')
+  const primary = style.getPropertyValue('--primary-interactive')
+  const secondary = style.getPropertyValue('--secondary-interactive')
+  const background = style.getPropertyValue('--secondary-background')
+  const info = style.getPropertyValue('--info')
+
+  const { dates, magnitudes, errors, chartMin, chartMax } = chartData.value
+
+  lightCurveChart = new Chart(lightCurveCanvas.value, {
+    type: 'line',
+    data: {
+      labels: dates,
+      datasets: [
+        {
+          label: 'Magnitude',
+          data: magnitudes,
+          order: 0,
+          // Line styling
+          borderColor: primary,
+          borderWidth: 2,
+          borderJoinStyle: 'round',
+          backgroundColor: primary,
+          cubicInterpolationMode: 'monotone',
+          tension: 0.4,
+          // Point hover styling
+          pointHoverBorderColor: secondary,
+          pointHoverBackgroundColor: secondary,
+        },
+        {
+          label: 'Mag Error',
+          data: errors,
+          order: 1,
+          type: 'bar',
+          // Error bar styling
+          borderColor: info,
+          backgroundColor: info,
+          barPercentage: 0.1,
+          hoverBackgroundColor: secondary,
+          hoverBorderColor: secondary,
+        }
+      ]
+    },
+    options: {
+      scales: {
+        x: {
+          type: 'timeseries',
+          title: { display: true, text: 'Date', color: text },
+          border: { color: text, width: 2 },
+          ticks: { color: text },
+          grid: { color: background },
+          time: {
+            unit: 'day',
+            tooltipFormat: 'MMM dd hh:mm a',
+            displayFormats: {
+              day: 'M/dd T'
+            },
+          }
+        },
+        y: {
+          min: chartMin,
+          max: chartMax,
+          title: { display: true, text: 'Magnitude', color: text },
+          border: { color: text, width: 2 },
+          ticks: { color: text },
+          grid: { color: background },
+        }
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: { mode: 'index', intersect: false },
+      },
+      hover: {
+        mode: 'index',
+        intersect: false,
+      }
+    }
+  })
+}
+
+</script>
+<template>
+  <canvas
+    ref="lightCurveCanvas"
+    class="light-curve-plot"
+  />
+</template>

--- a/src/components/Analysis/LightCurvePlot.vue
+++ b/src/components/Analysis/LightCurvePlot.vue
@@ -97,7 +97,7 @@ function createChart() {
           title: { display: true, text: 'Date', color: text },
           border: { color: text, width: 2 },
           ticks: { color: text },
-          grid: { color: background },
+          grid: { color: background, tickColor: text},
           time: {
             unit: 'day',
             tooltipFormat: 'MMM dd hh:mm a',
@@ -112,7 +112,7 @@ function createChart() {
           title: { display: true, text: 'Magnitude', color: text },
           border: { color: text, width: 2 },
           ticks: { color: text },
-          grid: { color: background },
+          grid: { color: background, tickColor: text},
         }
       },
       plugins: {

--- a/src/components/Analysis/PeriodPlot.vue
+++ b/src/components/Analysis/PeriodPlot.vue
@@ -20,10 +20,12 @@ const probabilityChipColor = computed(() => {
 })
 
 const chartData = computed(() => {
-  const phases = analysisStore.variableStarData.magPeriodogram.map(({ phase }) => phase.toFixed(DECIMAL_PLACES))
-  const secondPhases = analysisStore.variableStarData.magPeriodogram.map(({ phase }) => (phase + 1).toFixed(DECIMAL_PLACES))
-  const magnitudes = analysisStore.variableStarData.magPeriodogram.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
-  const errors = analysisStore.variableStarData.magPeriodogram.map(({ mag, magerr }) => {
+  const periodogram = analysisStore.variableStarData.magPeriodogram
+
+  const phases = periodogram.map(({ phase }) => phase.toFixed(DECIMAL_PLACES))
+  const secondPhases = periodogram.map(({ phase }) => (phase + 1).toFixed(DECIMAL_PLACES))
+  const magnitudes = periodogram.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
+  const errors = periodogram.map(({ mag, magerr }) => {
     const lowerBound = (mag - magerr).toFixed(DECIMAL_PLACES)
     const upperBound = (mag + magerr).toFixed(DECIMAL_PLACES)
     return [lowerBound, upperBound]
@@ -67,30 +69,32 @@ function createChart() {
   const { phases, magnitudes, errors, chartMin, chartMax } = chartData.value
 
   periodChart = new Chart(periodCanvas.value, {
-    type: 'line',
     data: {
-      labels: phases,
       datasets: [
         {
+          type: 'line',
           label: 'Magnitude',
-          data: magnitudes,
+          data: {
+            x: phases,
+            y: magnitudes
+          },
           order: 0,
           // Line styling
           borderColor: primary,
           borderWidth: 2,
-          borderJoinStyle: 'round',
           backgroundColor: primary,
-          cubicInterpolationMode: 'monotone',
-          tension: 0.4,
           // Point hover styling
           pointHoverBorderColor: secondary,
           pointHoverBackgroundColor: secondary,
         },
         {
-          label: 'Mag Error',
-          data: errors,
-          order: 1,
           type: 'bar',
+          label: 'Mag Error',
+          data: { 
+            x: phases,
+            y: errors
+          },
+          order: 1,
           // Error bar styling
           borderColor: info,
           backgroundColor: info,
@@ -103,17 +107,25 @@ function createChart() {
     options: {
       scales: {
         x: {
+          type: 'linear',
           title: { display: true, text: 'Phase', color: text },
           border: { color: text, width: 2 },
-          ticks: { color: text },
-          grid: { color: background },
+          ticks: { 
+            color: text, 
+            stepSize: 0.25,
+            callback: function(value) {
+              return value.toFixed(2)
+            }
+          },
+          grid: { color: background, offset: false },
         },
         y: {
+          type: 'linear',
           min: chartMin,
           max: chartMax,
           title: { display: true, text: 'Magnitude', color: text },
           border: { color: text, width: 2 },
-          ticks: { color: text },
+          ticks: { color: text, stepSize: 0.2 },
           grid: { color: background },
         }
       },

--- a/src/components/Analysis/PeriodPlot.vue
+++ b/src/components/Analysis/PeriodPlot.vue
@@ -1,19 +1,18 @@
 <script setup>
 import Chart from 'chart.js/auto'
-import 'chartjs-adapter-luxon'
 import { ref, watch, computed } from 'vue'
 import { useAnalysisStore } from '@/stores/analysis'
 
 const analysisStore = useAnalysisStore()
-const lightCurveCanvas = ref(null)
-let lightCurveChart = null
+const periodCanvas = ref(null)
+let periodChart = null
 const CHART_PADDING = 0.05
 const DECIMAL_PLACES = 4
 
 const chartData = computed(() => {
-  const phases = analysisStore.variableStarData.magTimeSeries.map(({ phase }) => phase.toFixed(DECIMAL_PLACES))
-  const magnitudes = analysisStore.variableStarData.magTimeSeries.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
-  const errors = analysisStore.variableStarData.magTimeSeries.map(({ mag, magerr }) => {
+  const phases = analysisStore.variableStarData.magPeriodogram.map(({ phase }) => phase.toFixed(DECIMAL_PLACES))
+  const magnitudes = analysisStore.variableStarData.magPeriodogram.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
+  const errors = analysisStore.variableStarData.magPeriodogram.map(({ mag, magerr }) => {
     const lowerBound = (mag - magerr).toFixed(DECIMAL_PLACES)
     const upperBound = (mag + magerr).toFixed(DECIMAL_PLACES)
     return [lowerBound, upperBound]
@@ -41,17 +40,18 @@ const probabilityChipColor = computed(() => {
 })
 
 watch(() => analysisStore.variableStarData, () => {
-  lightCurveChart && analysisStore.variableStarData.magTimeSeries ? updateChart() : createChart()
+  periodChart && analysisStore.variableStarData.magPeriodogram ? updateChart() : createChart()
 }, { deep: true})
 
 function updateChart() {
   // Updates the chart when user runs flux analysis again
-  lightCurveChart.data.labels = chartData.value.phases
-  lightCurveChart.data.datasets[0].data = chartData.value.magnitudes
-  lightCurveChart.data.datasets[1].data = chartData.value.errors
-  lightCurveChart.options.scales.y.min = chartData.value.chartMin
-  lightCurveChart.options.scales.y.max = chartData.value.chartMax
-  lightCurveChart.update()
+  const { phases, magnitudes, errors, chartMin, chartMax } = chartData.value
+  periodChart.data.labels = phases
+  periodChart.data.datasets[0].data = magnitudes
+  periodChart.data.datasets[1].data = errors
+  periodChart.options.scales.y.min = chartMin
+  periodChart.options.scales.y.max = chartMax
+  periodChart.update()
 }
 
 function createChart() {
@@ -63,7 +63,7 @@ function createChart() {
   const background = style.getPropertyValue('--secondary-background')
   const info = style.getPropertyValue('--info')
 
-  lightCurveChart = new Chart(lightCurveCanvas.value, {
+  periodChart = new Chart(periodCanvas.value, {
     type: 'line',
     data: {
       labels: chartData.value.phases,
@@ -130,8 +130,8 @@ function createChart() {
 <template>
   <div>
     <canvas
-      ref="lightCurveCanvas"
-      class="light-curve-plot"
+      ref="periodCanvas"
+      class="period-plot"
     />
     <div class="d-flex ga-2 pb-2">
       <v-chip color="var(--info)">

--- a/src/components/Analysis/PeriodPlot.vue
+++ b/src/components/Analysis/PeriodPlot.vue
@@ -87,14 +87,14 @@ function createChart() {
               return value.toFixed(2)
             }
           },
-          grid: { color: background },
+          grid: { color: background, tickColor: text },
         },
         y: {
           type: 'linear',
           title: { display: true, text: 'Magnitude', color: text },
           border: { color: text, width: 2 },
           ticks: { color: text, stepSize: 0.2 },
-          grid: { color: background },
+          grid: { color: background, tickColor: text},
           grace: '5%',
         }
       },

--- a/src/components/Analysis/VariableStarDialog.vue
+++ b/src/components/Analysis/VariableStarDialog.vue
@@ -50,8 +50,7 @@ watch([startDate, endDate], () => {
 }, { immediate: true })
 
 function dispatchVariableAnalysis() {
-  const variableStarActionName = 'variable-star'
-  emit ('analysisAction', variableStarActionName, {
+  emit ('analysisAction', 'variable-star', {
     images: matchingImages.value.results.map((image) => {
       return {
         id: image.id,
@@ -61,7 +60,7 @@ function dispatchVariableAnalysis() {
     }),
     target_coords: props.coords,
   })
-  analysisStore.lightCurveLoading = true
+  analysisStore.variableStarData.loading = true
   emit('closeDialog')
 }
 

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -24,10 +24,10 @@ export const useAnalysisStore = defineStore('analysis', {
     // Variable Star Analysis
     variableStarData: {
       loading: false, // flag to indicate if variable star data is loading
-      targetCoords: null, // target coordinates for the variable star
+      targetCoords: 0, // target coordinates for the variable star
       magTimeSeries: [], // time series data for the variable star
-      period: null, // period of the variable star
-      falseAlarmProbability: null, // false alarm probability for the variable star
+      period: 0, // period of the variable star
+      falseAlarmProbability: 0, // false alarm probability for the variable star
       fluxFallback: false, // flag to indicate if flux fallback is used
       excludedImages: [], // list of excluded images for the variable star
     },
@@ -121,7 +121,6 @@ export const useAnalysisStore = defineStore('analysis', {
       })
     },
     setLightCurveData(data) {
-      const VSTAR_SIGNIFICANT_DIGITS = 4
       const { light_curve, target_coords, period, fap, flux_fallback, excluded_images } = data
 
       this.$patch({
@@ -129,8 +128,8 @@ export const useAnalysisStore = defineStore('analysis', {
           loading: false,
           targetCoords: target_coords,
           magTimeSeries: light_curve,
-          period: period.toFixed(VSTAR_SIGNIFICANT_DIGITS),
-          falseAlarmProbability: fap.toFixed(VSTAR_SIGNIFICANT_DIGITS),
+          period: period,
+          falseAlarmProbability: fap,
           fluxFallback: flux_fallback,
           excludedImages: excluded_images,
         }
@@ -139,8 +138,8 @@ export const useAnalysisStore = defineStore('analysis', {
       // Fold the light curve data over the period
       function foldPeriod(magTimeSeries, period){
         magTimeSeries.forEach(mts => {
-          mts.jd_folded = (mts.julian_date % period).toFixed(VSTAR_SIGNIFICANT_DIGITS)
-          mts.phase = (mts.jd_folded / period).toFixed(VSTAR_SIGNIFICANT_DIGITS)
+          mts.jd_folded = (mts.julian_date % period)
+          mts.phase = (mts.jd_folded / period)
         })
       }
       

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -125,27 +125,27 @@ export const useAnalysisStore = defineStore('analysis', {
     setVariableStarData(data) {
       const { light_curve, target_coords, period, fap, flux_fallback, excluded_images } = data
 
-      this.$patch({
-        variableStarData: {
-          loading: false,
-          targetCoords: target_coords,
-          magTimeSeries: light_curve,
-          magPeriodogram: light_curve,
-          period: period,
-          falseAlarmProbability: fap,
-          fluxFallback: flux_fallback,
-          excludedImages: excluded_images,
-        }
-      })
-
-      // Fold the light curve data over the period
-      function foldPeriod(magTimeSeries, period){
-        magTimeSeries.forEach(mts => {
-          mts.jd_folded = (mts.julian_date % period)
-          mts.phase = (mts.jd_folded / period)
-        })
+      this.variableStarData = {
+        loading: false,
+        targetCoords: target_coords,
+        magTimeSeries: light_curve,
+        magPeriodogram: light_curve,
+        period: period,
+        falseAlarmProbability: fap,
+        fluxFallback: flux_fallback,
+        excludedImages: excluded_images,
       }
-      
+
+      function foldPeriod(magTimeSeries, period) {
+        // Perf testing shows precalculating the inverse is faster
+        const invPeriod = 1.0 / period
+  
+        for (let i = 0; i < magTimeSeries.length; i++) {
+          const mts = magTimeSeries[i]
+          mts.phase = (mts.julian_date % period) * invPeriod
+        }
+      }
+
       foldPeriod(this.variableStarData.magTimeSeries, this.variableStarData.period)
 
       // Sort the light curve data by phase

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -26,6 +26,7 @@ export const useAnalysisStore = defineStore('analysis', {
       loading: false, // flag to indicate if variable star data is loading
       targetCoords: 0, // target coordinates for the variable star
       magTimeSeries: [], // time series data for the variable star
+      magPeriodogram: [], // magTimeSeries sorted by phase
       period: 0, // period of the variable star
       falseAlarmProbability: 0, // false alarm probability for the variable star
       fluxFallback: false, // flag to indicate if flux fallback is used
@@ -128,6 +129,7 @@ export const useAnalysisStore = defineStore('analysis', {
           loading: false,
           targetCoords: target_coords,
           magTimeSeries: light_curve,
+          magPeriodogram: light_curve,
           period: period,
           falseAlarmProbability: fap,
           fluxFallback: flux_fallback,
@@ -146,7 +148,7 @@ export const useAnalysisStore = defineStore('analysis', {
       foldPeriod(this.variableStarData.magTimeSeries, this.variableStarData.period)
 
       // Sort the light curve data by phase
-      this.variableStarData.magTimeSeries.sort((a, b) => a.phase - b.phase)
+      this.variableStarData.magPeriodogram = [...this.variableStarData.magTimeSeries].sort((a, b) => a.phase - b.phase)
 
       this.variableStarData.loading = false
     }

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -37,6 +37,7 @@ export const useAnalysisStore = defineStore('analysis', {
     // General
     imageProposalId: (state) => { return state.image.proposal_id},
     imageFilter: (state) => { return state.image.FILTER },
+    loading: (state) => { return state.imageScaleLoading || state.variableStarData.loading },
     // Histogram Editing
     imageScaleReady: (state) => state.imageWidth && state.imageHeight && state.rawData && state.zmin != null && state.zmax != null,
     histogram: (state) => { return state.rawData.histogram },

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { markRaw } from 'vue'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
 import { fetchApiCall } from '@/utils/api.js'
@@ -91,6 +92,12 @@ export const useAnalysisStore = defineStore('analysis', {
 
       await fetchApiCall({url: url, method: 'POST', body: requestBody,
         successCallback: (response) => {
+          if (response.data){
+            // data is up to 1M pixels, so mark raw to prevent Vue from deep watching it
+            // This is a performance optimization to avoid unnecessary reactivity
+            // and is safe because we don't mutate the rawData object directly.
+            response.data = markRaw(response.data)
+          }
           this.rawData = response
           this.zmin = response.zmin
           this.zmax = response.zmax

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -122,7 +122,7 @@ export const useAnalysisStore = defineStore('analysis', {
         }
       })
     },
-    setLightCurveData(data) {
+    setVariableStarData(data) {
       const { light_curve, target_coords, period, fap, flux_fallback, excluded_images } = data
 
       this.$patch({

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -98,7 +98,7 @@ function handleAnalysisOutput(response, action, action_callback){
     break
   case 'variable-star':
     analysisStore.setLightCurveData(response)
-    sideChart.value = 'Light Curve'
+    sideChart.value = 'Periodogram'
     break
   case 'get-tif':
     action_callback(response.tif_url, props.image.basename, 'TIF')

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -232,7 +232,7 @@ function updateScaling(min, max){
         </v-expand-transition>
         <v-expand-transition>
           <v-sheet
-            v-show="lineProfile.length || analysisStore.lightCurve"
+            v-show="lineProfile.length || analysisStore.variableStarData.magTimeSeries.length"
             class="side-panel-item"
           >
             <v-select
@@ -250,7 +250,7 @@ function updateScaling(min, max){
               :end-coords="endCoords"
               :position-angle="positionAngle"
             />
-            <variable-star-plot v-show="analysisStore.lightCurve && sideChart === 'Light Curve'" />
+            <variable-star-plot v-show="analysisStore.variableStarData.magTimeSeries.length && sideChart === 'Light Curve'" />
           </v-sheet>
         </v-expand-transition>
       </div>

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -13,6 +13,7 @@ import ImageViewer from '@/components/Analysis/ImageViewer.vue'
 import LinePlot from '@/components/Analysis/LinePlot.vue'
 import PeriodPlot from '@/components/Analysis/PeriodPlot.vue'
 import LightCurvePlot from '@/components/Analysis/LightCurvePlot.vue'
+import { getActivePinia } from 'pinia'
 
 const props = defineProps({
   image: {
@@ -68,7 +69,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   imgWorker.terminate()
-  analysisStore.$reset()
+  analysisStore.$dispose()
+  delete getActivePinia().state.value[analysisStore.$id]
 })
 
 // This function runs when imageViewer emits an analysis-action event and should be extended to handle other analysis types

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -178,6 +178,13 @@ function updateScaling(min, max){
         @click="emit('closeAnalysisDialog')"
       />
     </v-toolbar>
+    <v-progress-linear
+      v-hide="!analysisStore.loading"
+      rounded
+      indeterminate
+      stream
+      color="var(--success)"
+    />
     <div class="analysis-content">
       <image-viewer
         :catalog="filteredCatalog"
@@ -211,11 +218,11 @@ function updateScaling(min, max){
         </v-expand-transition>
         <v-expand-transition>
           <v-sheet
+            v-if="analysisStore.imageScaleReady"
             class="side-panel-item"
             rounded
           >
             <histogram-slider
-              v-if="analysisStore.imageScaleReady"
               :histogram="analysisStore.histogram"
               :bins="analysisStore.bins"
               :max-value="analysisStore.maxPixelValue"
@@ -223,20 +230,6 @@ function updateScaling(min, max){
               :z-max="Number(analysisStore.zmax)"
               @update-scaling="updateScaling"
             />
-            <div
-              v-else-if="analysisStore.imageScaleLoading"
-              class="d-flex ga-4 align-center justify-center"
-            >
-              <p class="d-block">
-                Histogram
-              </p>
-              <v-progress-linear
-                color="var(--success)"
-                :height="6"
-                indeterminate
-                rounded
-              />
-            </div>
           </v-sheet>
         </v-expand-transition>
         <v-expand-transition>

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -11,7 +11,8 @@ import ImageDownloadMenu from '@/components/Global/ImageDownloadMenu.vue'
 import FitsHeaderTable from '@/components/Analysis/FitsHeaderTable.vue'
 import ImageViewer from '@/components/Analysis/ImageViewer.vue'
 import LinePlot from '@/components/Analysis/LinePlot.vue'
-import VariableStarPlot from '@/components/Analysis/VariableStarPlot.vue'
+import PeriodPlot from '@/components/Analysis/PeriodPlot.vue'
+import LightCurvePlot from '@/components/Analysis/LightCurvePlot.vue'
 
 const props = defineProps({
   image: {
@@ -48,6 +49,14 @@ const filteredCatalog = computed(() => {
     source.flux >= fluxSliderRange.value[0] &&
     source.flux <= fluxSliderRange.value[1]
   )
+})
+
+const sideChartItems = computed(() => {
+  const chartItems = []
+  if (analysisStore.variableStarData.magPeriodogram?.length) chartItems.push('Periodogram')
+  if (analysisStore.variableStarData.magTimeSeries?.length) chartItems.push('Light Curve')
+  if (lineProfile.value?.length) chartItems.push('Line Profile')
+  return chartItems
 })
 
 onMounted(() => {
@@ -237,7 +246,7 @@ function updateScaling(min, max){
           >
             <v-select
               v-model="sideChart"
-              :items="['Line Profile', 'Light Curve']"
+              :items="sideChartItems"
               variant="solo-filled"
               bg-color="var(--card-background)"
               density="compact"
@@ -250,7 +259,8 @@ function updateScaling(min, max){
               :end-coords="endCoords"
               :position-angle="positionAngle"
             />
-            <variable-star-plot v-show="analysisStore.variableStarData.magTimeSeries.length && sideChart === 'Light Curve'" />
+            <period-plot v-show="analysisStore.variableStarData.magPeriodogram.length && sideChart === 'Periodogram'" />
+            <light-curve-plot v-show="analysisStore.variableStarData.magTimeSeries.length && sideChart === 'Light Curve'" />
           </v-sheet>
         </v-expand-transition>
       </div>

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -97,13 +97,15 @@ function handleAnalysisOutput(response, action, action_callback){
     catalog.value = response
     break
   case 'variable-star':
-    analysisStore.setLightCurveData(response)
+    analysisStore.setVariableStarData(response)
     sideChart.value = 'Periodogram'
     break
   case 'get-tif':
+    // ImageDownloadMenu.vue downloadFile()
     action_callback(response.tif_url, props.image.basename, 'TIF')
     break
   case 'get-jpg':
+    // ImageDownloadMenu.vue downloadFile()
     action_callback(response.jpg_base64, props.image.basename, 'base64')
     break
   default:
@@ -194,7 +196,7 @@ function updateScaling(min, max){
         <v-expand-transition>
           <v-sheet
             v-if="catalog.length"
-            class="side-panel-item image-controls-sheet"
+            class="side-panel-item"
           >
             <div class="d-flex align-center mb-2">
               <v-btn

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -127,10 +127,12 @@ async function instantiateScalerWorker(){
   imgScalingCanvas.height = analysisStore.imageHeight
   const offscreen = imgScalingCanvas.transferControlToOffscreen()
 
+  const rawDataCopy = JSON.parse(JSON.stringify(analysisStore.rawData))
+
   // Post the image data to the worker
   imgWorker.postMessage({
     canvas: offscreen,
-    imageData: structuredClone(analysisStore.rawData)
+    imageData: rawDataCopy,
   }, [offscreen])
 
   // Image creation for leaflet map, clean up the old image url


### PR DESCRIPTION
Paired with https://github.com/LCOGT/ptr_datalab/pull/104 on the backend

Uses the period and false alarm probability provided by the backend to fold the existing light curve into phases that align with the predicted period for that star. This is shown in the new Periodogram graph.

LightCurvePlot.vue
- changed padding to 0.5
- cut off decimal places to the 4th
- improve naming
- use destructuring for assignments

PeriodPlot.vue
- New Chart.js Plot
- instead of plotting magnitude on time, plots it on phase
- Values duplicated to show the period twice

VariableStarDialog.vue
- small changes to adjust to store

analysis.js
- variableStarData object in store that contains everything for light analysis
- new loading getter for global analysisView progress bar
- folding logic when we set the light curve data

AnalysisView.vue
- computed property sideChartItems to display options for sidechart based on whats available
- unified progress bar for the whole analysisView
- added periodPlot
- renamed VariableStarPlot to LightCurvePlot

Rachel's old tool
<img width="748" height="266" alt="image" src="https://github.com/user-attachments/assets/7b1c9dbe-4686-43ba-bab2-a7528fb49bc4" />

Datalab
As for the negatives for the magnitude that needs to be changed on the backend and its a formula for converting flux to mag that I need to better understand why it outputs a negative before changing it
<img width="1089" height="658" alt="Screenshot 2025-08-12 at 3 04 22 PM" src="https://github.com/user-attachments/assets/63ed1af0-1ce7-41b6-a854-7f11b3e60fc2" />

