### PR TITLE
Add drag and drop for image selection in the operation wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "serve": "^14.2.1",
         "update": "^0.7.4",
         "vue": "^3.5.9",
+        "vue-easy-dnd": "^2.2.2",
         "vue-router": "^4.2.5",
         "vuetify": "^3.7.4",
         "webfontloader": "^1.0.0"
@@ -14681,6 +14682,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -20602,6 +20609,19 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/vue-easy-dnd": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/vue-easy-dnd/-/vue-easy-dnd-2.2.2.tgz",
+      "integrity": "sha512-2pZAGq6FufiP/5ZP0k5guR6dqYo4oIgdMSiDoIm1AmZx2tNsQT/XCri2lIb9lW/H2NZnrUhgbn+oSOfMUuNcFg==",
+      "license": "MIT",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "vue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "serve": "^14.2.1",
     "update": "^0.7.4",
     "vue": "^3.5.9",
+    "vue-easy-dnd": "^2.2.2",
     "vue-router": "^4.2.5",
     "vuetify": "^3.7.4",
     "webfontloader": "^1.0.0"

--- a/src/components/DataSession/MultiImageInputSelector.vue
+++ b/src/components/DataSession/MultiImageInputSelector.vue
@@ -1,0 +1,190 @@
+<script>
+import { useThumbnailsStore } from '@/stores/thumbnails'
+import { useConfigurationStore } from '@/stores/configuration'
+import ThumbnailImage from '@/components/Global/ThumbnailImage.vue'
+import {Drag,DropList} from 'vue-easy-dnd'
+import { ref } from 'vue'
+
+export default {
+  name: 'MultiImageInputSelector',
+  components: {
+    Drag, DropList, ThumbnailImage
+  },
+  props: {
+    inputDescriptions: {
+      type: Object,
+      default: () => {}
+    },
+    selectedImages: {
+      type: Object,
+      default: () => {}
+    },
+    images: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['insertSelectedImage', 'removeSelectedImage'],
+  data: function () {
+    return {
+      thumbnailsStore: useThumbnailsStore(),
+      configurationStore: useConfigurationStore(),
+      imageDetails: {},
+      filterToColor: {
+        'r': 'red',
+        'rp': 'red',
+        'ip': 'red',
+        'h-alpha': 'purple',
+        'v': 'green',
+        'gp': 'green',
+        'oiii': 'green',
+        'b': 'blue',
+        'sii': 'blue'
+      }
+    }
+  },
+  computed: {
+    columnSize: function() {
+      const inputCount = Object.keys(this.inputDescriptions).length
+      return Math.floor(12 / inputCount)
+    }
+  },
+  methods: {
+    insert(inputKey, event) {
+      if (inputKey !== 'all' && ! this.selectedImages[inputKey].includes(event.data)) {
+        this.$emit('insertSelectedImage', inputKey, event.data)
+      }
+    },
+    remove(inputKey, value) {
+      if (inputKey !== 'all') {
+        this.$emit('removeSelectedImage', inputKey, value)
+      }
+    },
+    reloadImages(newImages) {
+      let newImageDetails = {}
+      newImages.forEach(image => {
+        if (image.basename && !(image.basename in newImageDetails)) {
+          newImageDetails[image.basename] = ref('')
+          const url = image.smallThumbUrl || image.small_url ||''
+          this.thumbnailsStore.cacheImage('small', this.configurationStore.archiveType, url, image.basename).then((cachedUrl) => {
+            newImageDetails[image.basename].value = cachedUrl
+          })
+        }
+      })
+      return newImageDetails
+    },
+    colorFromInput(inputKey) {
+      if (this.inputDescriptions[inputKey].filter) {
+        return this.filterToColor[this.inputDescriptions[inputKey].filter[0]]
+      }
+      return 'white'
+    }
+  },
+  mounted() {
+    this.imageDetails = this.reloadImages(this.images)
+  },
+}
+</script>
+
+<template>
+  <v-row>
+    <v-col
+      v-for="inputKey in Object.keys(this.inputDescriptions)"
+      :key="inputKey"
+      :cols="columnSize"
+      class="drop-section"
+    >
+    <v-card :title="'Selected ' + this.inputDescriptions[inputKey].name + ':'" variant="outlined" density="compact" elevation="0" :color="colorFromInput(inputKey)">
+      <v-card-text>
+        <drop-list :items="this.selectedImages[inputKey]" @insert="insert(inputKey, $event)" mode="cut" :row="true" class="drop-section">
+          <template v-slot:item="{item}">
+            <drag :key="inputKey + '-' + item.basename" :data="item" @cut="remove(inputKey, item)" class="m-1 fill-width">
+              <thumbnail-image
+                :image="item"
+                :image-url="this.imageDetails[item.basename]"
+                :enable-image-cards="false"
+                :enable-removal="true"
+                @remove-image="remove(inputKey, $event)"
+              ></thumbnail-image>
+            </drag>
+          </template>
+          <template v-slot:inserting-drag-image="{data}">
+            <div :key="inputKey + '-' + data.basename + '-inserting-drag-image'">
+              <h2>Inserting</h2>
+            </div>
+        </template>
+          <template v-slot:feedback="{data}">
+            <thumbnail-image
+                :image="data"
+                :image-url="this.imageDetails[data.basename]"
+                :enable-image-cards="false"
+                :enable-removal="true"
+                @remove-image="remove(inputKey, $event)"
+                :key="inputKey + '-' + data.basename + '-feedback'"
+              ></thumbnail-image>
+          </template>
+        </drop-list>
+      </v-card-text>
+    </v-card>
+    </v-col>
+  </v-row>
+  <v-row>
+    <v-col v-if="this.imageDetails">
+      <v-card title="Select Images from:" variant="outlined" density="compact">
+        <v-card-text>
+          <drop-list :items="this.images" @insert="insert('all', $event)" mode="cut" :row="true" :no-animations="true">
+            <template v-slot:item="{item}">
+              <drag :key="'all-' + item.basename" :data="item" @cut="remove('all', item)" class="m-2 list-image">
+                <thumbnail-image
+                  :image="item"
+                  :image-url="this.imageDetails[item.basename]"
+                  :enable-image-cards="false"
+                ></thumbnail-image>
+              </drag>
+            </template>
+            <template v-slot:feedback="{data}">
+              <div class="list-image" :key="'all-' + data.basename + '-feedback'"></div>
+            </template>
+            <template v-slot:reordering-feedback="{item}">
+              <div class="list-image" :key="'all-' + item.basename + '-reordering-feedback'"></div>
+            </template>
+          </drop-list>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<style scoped>
+
+.dnd-image {
+  max-width: 200px;
+  min-width: 120px;
+  width: 100%;
+}
+
+.list-image {
+  display: inline-block;
+}
+
+.fill-width {
+  width: 100%;
+}
+
+.empty-slot {
+  flex: 0 0 0;
+  align-self: stretch;
+  outline: 1px solid blue;
+}
+
+.drop-section {
+  border-width: 2px;
+  flex-direction: row;
+  border-color: white;
+  width: 100%;
+  min-width: 200px;
+  min-height: 200px;
+  display: flex;
+}
+
+</style>

--- a/src/components/DataSession/OperationWizard.vue
+++ b/src/components/DataSession/OperationWizard.vue
@@ -1,11 +1,9 @@
 <script setup>
 import { ref, onMounted, computed} from 'vue'
 import { fetchApiCall, handleError } from '@/utils/api'
-import { calculateColumnSpan } from '@/utils/common'
-import ImageGrid from '../Global/ImageGrid'
-import ImageScalingGroup from '../Global/Scaling/ImageScalingGroup'
+import MultiImageInputSelector from '@/components/DataSession/MultiImageInputSelector.vue'
+import ImageScalingGroup from '@/components/Global/Scaling/ImageScalingGroup'
 import { useConfigurationStore } from '@/stores/configuration'
-import { useAlertsStore } from '@/stores/alerts'
 
 const props = defineProps({
   images: {
@@ -15,14 +13,12 @@ const props = defineProps({
 })
 
 const store = useConfigurationStore()
-const alert = useAlertsStore()
 const emit = defineEmits(['closeWizard', 'addOperation'])
 const dataSessionsUrl = store.datalabApiBaseUrl
 
 const availableOperations = ref({})
 const selectedOperation = ref('')
 const operationInputs = ref({})
-const IMAGES_PER_ROW = 3
 
 const WIZARD_PAGES = {
   SELECT: 'select',
@@ -53,6 +49,12 @@ const goForwardText = computed(() => {
 const wizardTitle = computed(() => {
   if (page.value == WIZARD_PAGES.SELECT) {
     return 'SELECT OPERATION'
+  }
+  else if (page.value == WIZARD_PAGES.SCALING) {
+    return 'Configure ' + selectedOperation.value.name + ' Operation: Select scale points for each channel'
+  }
+  else if (page.value == WIZARD_PAGES.CONFIGURE && operationRequiresInputScaling.value) {
+    return 'Configure ' + selectedOperation.value.name + ' Operation: Select input images for channels'
   }
   else {
     return 'Configure ' + selectedOperation.value.name + ' Operation'
@@ -89,6 +91,13 @@ const operationRequiresInputScaling = computed(() => {
   return false
 })
 
+const imageInputDescriptions = computed(() => {
+  if (inputDescriptions.value) {
+    return Object.fromEntries(Object.entries(inputDescriptions.value).filter(([, inputDescription]) => inputDescription.type == 'fits'))
+  }
+  return {}
+})
+
 onMounted(async () => {
   // Fetch available operations from the server
   const url = dataSessionsUrl + 'available_operations/'
@@ -104,38 +113,6 @@ function updateScaling(imageName, zmin, zmax) {
   // that will then be sent to the server when we add the operation
   operationInputs.value[imageName][0].zmin = zmin
   operationInputs.value[imageName][0].zmax = zmax
-}
-
-function sortImagesByFilter(filters, images){
-  // Trim and lowercase all filters
-  for (const filter in filters){
-    filters[filter] = filters[filter].trim().toLowerCase()
-  }
-  // Place desired filters at the front, followed by the rest
-  return [
-    ...images.filter(image => filters.includes(image.filter?.trim().toLowerCase())),
-    ...images.filter(image => !filters.includes(image.filter?.trim().toLowerCase()))
-  ]
-}
-
-function validatedImages(inputDescription) {
-  try {
-    const validatedImages = props.images.filter(image => {
-      // archive images have no type (assigned in backend outputs) so we accept null for 'fits' format
-      const inputIsFormatFitsAndArchiveImage = inputDescription.type == 'fits' && image.type == null
-      return (inputIsFormatFitsAndArchiveImage || image.type == inputDescription.type)
-    })
-
-    // If the input has a filter, sort the images by that filter
-    if(inputDescription.filter) 
-      return sortImagesByFilter(inputDescription.filter, validatedImages)
-    else
-      return validatedImages
-
-  } catch (error) {
-    console.log('Error validating images:', error)
-    return props.images // fallback to all images
-  }
 }
 
 function goForward() {
@@ -182,24 +159,6 @@ function submitOperation() {
   emit('closeWizard')
 }
 
-function selectImage(inputKey, basename) {
-  const inputKeyImages = operationInputs.value[inputKey]
-  const input = inputDescriptions.value[inputKey]
-  const image = props.images.find(image => image.basename == basename)
-
-  // If the image is already selected, remove it from the list
-  if (inputKeyImages.includes(image)) {
-    inputKeyImages.splice(inputKeyImages.indexOf(image), 1)
-  }
-  // If image not selected and maxImages isn't reached, add to the list
-  else if (!input.maximum || inputKeyImages.length < input.maximum) {
-    inputKeyImages.push(image)
-  }
-  else {
-    alert.setAlert('warning', `${input.name} can only have ${input.maximum} image(s) selected`)
-  }
-}
-
 function selectOperation(name) {
   selectedOperation.value = availableOperations.value[name]
   operationInputs.value = {}
@@ -207,10 +166,37 @@ function selectOperation(name) {
     if ('default' in value) {
       operationInputs.value[key] = value.default
     }
+    else if (value.maximum === 1 && value.filter) {
+      // If this entry wants on file and has pre-specified filter preferences, preselect the closest file for them
+      const preselectedImage = props.images.find(image => value.filter.includes(image.filter?.trim().toLowerCase()))
+      if (preselectedImage) {
+        operationInputs.value[key] = [preselectedImage]
+      }
+    }
     else {
       operationInputs.value[key] = []
     }
   }
+}
+
+function insertSelectedImage(inputKey, image) {
+  if (inputKey in operationInputs.value && !operationInputs.value[inputKey].includes(image)) {
+    if (imageInputDescriptions.value[inputKey].maximum === 1) {
+      // This case of only wanting a single image should have the behavior of replacing the image rather than adding to the list of inputs
+      operationInputs.value[inputKey] = [image]
+    }
+    else if(operationInputs.value[inputKey].length >= imageInputDescriptions.value[inputKey].maximum) {
+      operationInputs.value[inputKey].pop(image)
+      operationInputs.value[inputKey].push(image)
+    }
+    else{
+      operationInputs.value[inputKey].push(image)
+    }
+  }
+}
+
+function removeSelectedImage(inputKey, image) {
+  operationInputs.value[inputKey].splice(operationInputs.value[inputKey].indexOf(image), 1)
 }
 
 </script>
@@ -262,6 +248,16 @@ function selectOperation(name) {
         v-show="page == WIZARD_PAGES.CONFIGURE"
         class="wizard-card"
       >
+        <div class="operation-input-wrapper">
+          <multi-image-input-selector
+            :inputDescriptions="imageInputDescriptions"
+            :selectedImages="operationInputs"
+            :images="props.images"
+            @insert-selected-image="insertSelectedImage"
+            @remove-selected-image="removeSelectedImage"
+          >
+          </multi-image-input-selector>
+        </div>
         <div
           v-for="(inputDescription, inputKey) in inputDescriptions"
           :key="inputKey"
@@ -274,23 +270,6 @@ function selectOperation(name) {
             :type="inputDescription.type"
             class="operation-input"
           />
-          <div v-else-if="inputDescription.type == 'fits'">
-            <div
-              v-if="inputDescription.name"
-              class="input-images"
-            >
-              {{ inputDescription.name }}
-            </div>
-            <image-grid
-              v-if="operationInputs[inputKey]"
-              :images="validatedImages(inputDescription)"
-              :selected-images="operationInputs[inputKey].map(image => image.basename)"
-              :column-span="calculateColumnSpan(images.length, IMAGES_PER_ROW)"
-              :allow-selection="true"
-              :enable-image-cards="false"
-              @select-image="selectImage(inputKey, $event)"
-            />
-          </div>
         </div>
       </v-card-text>
     </v-slide-y-reverse-transition>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -3,8 +3,7 @@ import { ref, watch } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
-import ImageDownloadMenu from '@/components/Global/ImageDownloadMenu.vue'
-import FilterBadge from './FilterBadge.vue'
+import ThumbnailImage from '@/components/Global/ThumbnailImage.vue'
 import AnalysisView from '../../views/AnalysisView.vue'
 
 const props = defineProps({
@@ -83,58 +82,15 @@ watch(() => props.images, () => {
       :cols="columnSpan"
       class="image-grid-col"
     >
-      <v-sheet
-        v-if="image.basename in imageDetails && imageDetails[image.basename]"
-        class="pa-2"
-        color="var(--secondary-background)"
-        :elevation="2"
-        rounded
-        :class="{ 'selected-image': isSelected(image.basename) }"
-        @click="emit('selectImage', image.basename)"
-      >
-        <v-img
-          :src="imageDetails[image.basename]"
-          :alt="image.basename"
-          rounded
-          cover
-          aspect-ratio="1"
-        >
-          <filter-badge
-            v-if="image.filter || image.FILTER"
-            :filter="image.filter || image.FILTER"
-          />
-          <span
-            v-if="'operationIndex' in image"
-            class="image-text-overlay"
-          >{{ image.operationIndex }}</span>
-        </v-img>
-        <div
-          v-if="props.enableImageCards"
-          class="d-flex flex-row ga-2 align-center mt-2"
-        >
-          <p class="text-subtitle-2 mr-auto prevent-select single-line-text">
-            {{ image.target_name || image.operationName }}
-          </p>
-          <v-icon
-            icon="mdi-eye"
-            color="var(--primary-interactive)"
-            @click.stop="launchAnalysis(image)"
-          />
-          <image-download-menu
-            :fits-url="image.url || image.fits_url || ''"
-            :jpg-url="image.largeCachedUrl || image.large_url || ''"
-            :image-name="image.basename"
-            speed-dial-location="top right"
-            :enable-scaled-download="false"
-          />
-        </div>
-      </v-sheet>
-      <v-skeleton-loader
-        v-else
-        type="card"
-        color="var(--secondary-background)"
-        bg-color="var(--primary-background)"
-      />
+      <thumbnail-image
+        :image="image"
+        :image-url="imageDetails[image.basename]"
+        :is-selected="isSelected(image.basename)"
+        :enable-image-cards="true"
+        :enable-removal="false"
+        @select-image="emit('selectImage', image.basename)"
+        @launch-analysis="launchAnalysis(image)"
+      ></thumbnail-image>
     </v-col>
   </v-row>
   <v-dialog

--- a/src/components/Global/ThumbnailImage.vue
+++ b/src/components/Global/ThumbnailImage.vue
@@ -1,0 +1,117 @@
+<script setup>
+import ImageDownloadMenu from '@/components/Global/ImageDownloadMenu.vue'
+import FilterBadge from './FilterBadge.vue'
+
+const props = defineProps({
+  image: {
+    type: Object,
+    default: () => {}
+  },
+  imageUrl: {
+    type: String,
+    default: ''
+  },
+  isSelected: {
+    type: Boolean,
+    default: false
+  },
+  enableImageCards: {
+    type: Boolean,
+    default: true
+  },
+  enableRemoval: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['selectImage', 'launchAnalysis', 'removeImage'])
+
+</script>
+<template>
+      <v-sheet
+        v-if="props.imageUrl"
+        :key="props.imageUrl"
+        class="pa-1 annotated-image"
+        color="var(--secondary-background)"
+        :elevation="2"
+        rounded
+        :class="{ 'selected-image': isSelected }"
+        @click="emit('selectImage', props.image.basename)"
+      >
+        <v-img
+          :src="props.imageUrl"
+          :alt="props.image.basename"
+          rounded
+          cover
+          aspect-ratio="1"
+          ondragstart="return false;"
+        >
+          <filter-badge
+            v-if="props.image.filter || props.image.FILTER"
+            :filter="props.image.filter || props.image.FILTER"
+          />
+          <span
+            v-if="'operationIndex' in image"
+            class="image-text-overlay"
+          >{{ props.image.operationIndex }}</span>
+          <span
+            v-if="props.enableRemoval"
+            class="removal-button-overlay"
+          >
+            <v-btn density="compact" icon="mdi-close" @click="emit('removeImage', props.image)"></v-btn>
+          </span>
+        </v-img>
+        <div
+          v-if="props.enableImageCards"
+          class="d-flex flex-row ga-2 align-center mt-2"
+        >
+          <p class="text-subtitle-2 mr-auto prevent-select single-line-text">
+            {{ props.image.target_name || props.image.operationName }}
+          </p>
+          <v-icon
+            icon="mdi-eye"
+            color="var(--primary-interactive)"
+            @click.stop="emit('launchAnalysis', props.image)"
+          />
+          <image-download-menu
+            :fits-url="props.image.url || props.image.fits_url || ''"
+            :jpg-url="props.image.largeCachedUrl || props.image.large_url || ''"
+            :image-name="props.image.basename"
+            speed-dial-location="top right"
+            :enable-scaled-download="false"
+          />
+        </div>
+      </v-sheet>
+      <v-skeleton-loader
+        v-else
+        type="card"
+        color="var(--secondary-background)"
+        bg-color="var(--primary-background)"
+      />
+</template>
+
+<style scoped>
+.annotated-image {
+  max-width: 200px;
+  min-width: 120px;
+  width: 100%;
+}
+
+.selected-image {
+  outline: 0.3rem solid var(--primary-interactive);
+}
+.image-text-overlay {
+  color: var(--text);
+  font-weight: bold;
+  margin-right: 5px;
+  float: right;
+}
+.removal-button-overlay {
+  color: var(--text);
+  font-weight: bold;
+  right: 5px;
+  bottom: 5px;
+  position: absolute;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import 'leaflet/dist/leaflet.css'
 import './assets/css/ptr-extra.css'
 import 'bulma/css/bulma.css'
 import '@vue-flow/core/dist/style.css'
+import 'vue-easy-dnd/dist/dnd.css'
 
 loadFonts()
 


### PR DESCRIPTION
First cut at adding drag and drop support - haven't tested this on Ipad yet, just on my computer. I refactored the image stuff out of ImageGrid.vue into ThumbnailImage.vue to reuse that portion with the new MultiImageInputSelector.vue component

[datalab_image_selection_dnd.webm](https://github.com/user-attachments/assets/a472bdc5-b9fe-4331-8ffb-dfe71bac2197)
