### PR TITLE
decouple light curve from periodogram so it still works if period fails

### DIFF
--- a/src/components/Analysis/LightCurvePlot.vue
+++ b/src/components/Analysis/LightCurvePlot.vue
@@ -11,7 +11,7 @@ const CHART_PADDING = 0.5
 const DECIMAL_PLACES = 4
 
 const chartData = computed(() => {
-  const magTimeSeries = analysisStore.variableStarData.magTimeSeries
+  const magTimeSeries = analysisStore.magTimeSeries
 
   const dates = magTimeSeries.map(({ julian_date }) => julian_date)
   const magnitudes = magTimeSeries.map(({ mag }) => mag.toFixed(DECIMAL_PLACES))
@@ -31,7 +31,7 @@ const chartData = computed(() => {
 })
 
 watch(() => analysisStore.variableStarData, () => {
-  lightCurveChart && analysisStore.variableStarData.magTimeSeries ? updateChart() : createChart()
+  lightCurveChart && analysisStore.magTimeSeries ? updateChart() : createChart()
 }, { deep: true})
 
 function updateChart() {

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -22,11 +22,12 @@ export const useAnalysisStore = defineStore('analysis', {
     imageWidth: null, // width of the image in pixels
     imageHeight: null, // height of the image in pixels
     imageScaleLoading: false, // flag to indicate if the image scale is loading
+    // Light Curve
+    magTimeSeries: [], // time series data for the variable star
     // Variable Star Analysis
     variableStarData: {
       loading: false, // flag to indicate if variable star data is loading
       targetCoords: 0, // target coordinates for the variable star
-      magTimeSeries: [], // time series data for the variable star
       magPeriodogram: [], // magTimeSeries sorted by phase
       period: 0, // period of the variable star
       falseAlarmProbability: 0, // false alarm probability for the variable star
@@ -132,16 +133,7 @@ export const useAnalysisStore = defineStore('analysis', {
     setVariableStarData(data) {
       const { light_curve, target_coords, period, fap, flux_fallback, excluded_images } = data
 
-      this.variableStarData = {
-        loading: false,
-        targetCoords: target_coords,
-        magTimeSeries: light_curve,
-        magPeriodogram: light_curve,
-        period: period,
-        falseAlarmProbability: fap,
-        fluxFallback: flux_fallback,
-        excludedImages: excluded_images,
-      }
+      this.magTimeSeries = light_curve
 
       function foldPeriod(magTimeSeries, period) {
         // Perf testing shows precalculating the inverse is faster
@@ -153,10 +145,22 @@ export const useAnalysisStore = defineStore('analysis', {
         }
       }
 
-      foldPeriod(this.variableStarData.magTimeSeries, this.variableStarData.period)
+      if(period && this.magTimeSeries.length > 0){
+        this.variableStarData = {
+          loading: false,
+          targetCoords: target_coords,
+          magPeriodogram: [],
+          period: period,
+          falseAlarmProbability: fap,
+          fluxFallback: flux_fallback,
+          excludedImages: excluded_images,
+        }
+      
+        foldPeriod(this.magTimeSeries, this.variableStarData.period)
 
-      // Sort the light curve data by phase
-      this.variableStarData.magPeriodogram = [...this.variableStarData.magTimeSeries].sort((a, b) => a.phase - b.phase)
+        // Sort the light curve data by phase
+        this.variableStarData.magPeriodogram = [...this.magTimeSeries].sort((a, b) => a.phase - b.phase)
+      }
 
       this.variableStarData.loading = false
     }

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -56,7 +56,7 @@ const filteredCatalog = computed(() => {
 const sideChartItems = computed(() => {
   const chartItems = []
   if (analysisStore.variableStarData.magPeriodogram?.length) chartItems.push('Periodogram')
-  if (analysisStore.variableStarData.magTimeSeries?.length) chartItems.push('Light Curve')
+  if (analysisStore.magTimeSeries?.length) chartItems.push('Light Curve')
   if (lineProfile.value?.length) chartItems.push('Line Profile')
   return chartItems
 })
@@ -104,7 +104,8 @@ function handleAnalysisOutput(response, action, action_callback){
     break
   case 'variable-star':
     analysisStore.setVariableStarData(response)
-    sideChart.value = 'Periodogram'
+    // Default to periodogram if available, otherwise light curve
+    analysisStore.variableStarData.period ? sideChart.value = 'Periodogram' : sideChart.value = 'Light Curve'
     break
   case 'get-tif':
     // ImageDownloadMenu.vue downloadFile()
@@ -245,7 +246,7 @@ function updateScaling(min, max){
         </v-expand-transition>
         <v-expand-transition>
           <v-sheet
-            v-show="lineProfile.length || analysisStore.variableStarData.magTimeSeries.length"
+            v-show="lineProfile.length || analysisStore.magTimeSeries.length"
             class="side-panel-item"
           >
             <v-select
@@ -256,15 +257,15 @@ function updateScaling(min, max){
               density="compact"
             />
             <line-plot
-              v-show="lineProfile.length && sideChart === 'Line Profile'"
+              v-show="lineProfile?.length && sideChart === 'Line Profile'"
               :y-axis-data="lineProfile"
               :x-axis-length="lineProfileLength"
               :start-coords="startCoords"
               :end-coords="endCoords"
               :position-angle="positionAngle"
             />
-            <period-plot v-show="analysisStore.variableStarData.magPeriodogram.length && sideChart === 'Periodogram'" />
-            <light-curve-plot v-show="analysisStore.variableStarData.magTimeSeries.length && sideChart === 'Light Curve'" />
+            <period-plot v-show="analysisStore.variableStarData.magPeriodogram?.length && sideChart === 'Periodogram'" />
+            <light-curve-plot v-show="analysisStore.magTimeSeries?.length && sideChart === 'Light Curve'" />
           </v-sheet>
         </v-expand-transition>
       </div>


### PR DESCRIPTION
This leads to more graceful failure, program won't load endlessly anymore and light curve for the star will still be shown.

- Decouples the `magTimeSeries` data from the periodogram so we can still display light curves when the period fails to calculate
- Checks that there is period data before doing the period folding work

Paired with: https://github.com/LCOGT/ptr_datalab/pull/107