### PR TITLE
Text/explanation for discrepancy

### DIFF
--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -222,7 +222,7 @@ function createCatalogLayer(){
     })
 
     // Create a circle marker for the source
-    return new L.Circle([source.y, source.x], {
+    return new L.Circle([source.y_win, source.x_win], {
       color: 'var(--info)',
       fillOpacity: 0.2,
       radius: 3,

--- a/src/components/Analysis/LinePlot.vue
+++ b/src/components/Analysis/LinePlot.vue
@@ -114,6 +114,7 @@ function distanceLabel(){
     />
     <div class="line-details">
       <template v-if="startCoords && endCoords">
+        <p>PRECISE ASTROMETRIC COORDINATES</p>
         <p><b>Start:</b> RA {{ startCoords[0].toFixed(6) }} Dec {{ startCoords[1].toFixed(6) }}</p>
         <p><b>End:</b> RA {{ endCoords[0].toFixed(6) }} Dec {{ endCoords[1].toFixed(6) }}</p>
       </template>


### PR DESCRIPTION

Added the text `PRECISE ASTROMETRIC COORDINATES` because the ra and dec are different. The one not in the image is more precise.
<img width="1180" height="943" alt="Screenshot 2025-10-16 at 2 08 53 PM" src="https://github.com/user-attachments/assets/862fbb60-ebfb-4479-8f88-096b5c1abf9d" />
