### PR TITLE
Feature/slideshow

### DIFF
--- a/src/components/Analysis/FitsHeaderTable.vue
+++ b/src/components/Analysis/FitsHeaderTable.vue
@@ -13,12 +13,20 @@ const tableHeaders = [
   { title: 'Value', sortable: false, key:'1' },
 ]
 
+const basenameSequence = computed(() => {
+  const basename = analysisStore.image?.basename || ''
+  const match = basename.match(/^[^-]+-[^-]+-[^-]+-([^-]+)-e91$/)
+
+  return match?.[1] || 'Unknown'
+})
+
 // Loopable chip dict for v-chips
 const headerChips = computed(() => [
   { icon: 'mdi-earth', text: siteIDToName(analysisStore.headerData.SITEID) },
   { icon: 'mdi-telescope', text: analysisStore.headerData.TELID },
   { icon: 'mdi-camera', text: analysisStore.headerData.INSTRUME },
-  { icon: 'mdi-clock', text: new Date(analysisStore.headerData.DATE).toLocaleString() }
+  { icon: 'mdi-clock', text: new Date(analysisStore.headerData.DATE).toLocaleString() },
+  { icon: 'mdi-numeric', text: basenameSequence.value }
 ])
 
 </script>

--- a/src/components/Analysis/FitsHeaderTable.vue
+++ b/src/components/Analysis/FitsHeaderTable.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed } from 'vue'
-import { siteIDToName } from '@/utils/common'
+import { basenameToSequence, siteIDToName } from '@/utils/common'
 import { useAnalysisStore } from '@/stores/analysis'
 
 const analysisStore = useAnalysisStore()
@@ -13,12 +13,7 @@ const tableHeaders = [
   { title: 'Value', sortable: false, key:'1' },
 ]
 
-const basenameSequence = computed(() => {
-  const basename = analysisStore.image?.basename || ''
-  const match = basename.match(/^[^-]+-[^-]+-[^-]+-([^-]+)-e91$/)
-
-  return match?.[1] || 'Unknown'
-})
+const basenameSequence = computed(() => basenameToSequence(analysisStore.image?.basename || ''))
 
 // Loopable chip dict for v-chips
 const headerChips = computed(() => [

--- a/src/components/Analysis/ImageViewer.vue
+++ b/src/components/Analysis/ImageViewer.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, ref, nextTick, watch } from 'vue'
+import { onMounted, onUnmounted, ref, nextTick, watch } from 'vue'
 import L from 'leaflet'
 import '@geoman-io/leaflet-geoman-free'
 import '@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css'
@@ -37,11 +37,36 @@ const isHoveringLeaflet = ref(false)
 const raDec = ref({ ra: 0, dec: 0 })
 const alerts = useAlertsStore()
 const analysisStore = useAnalysisStore()
+let viewerInstanceId = 0
 
 onMounted(() => {
   // Initialize the map and its event listeners before adding the image overlay
   createMap()
   addMapHandlers()
+
+  if (analysisStore.imageUrl) {
+    initImageOverlay(analysisStore.imageUrl)
+  }
+
+  if (props.catalog?.length) {
+    createCatalogLayer()
+  }
+})
+
+onUnmounted(() => {
+  viewerInstanceId += 1
+
+  if (imageMap) {
+    imageMap.off()
+    imageMap.remove()
+  }
+
+  imageMap = null
+  imageBounds = null
+  imageOverlay = null
+  lineLayer = null
+  wcs = null
+  catalogLayerGroup = null
 })
 
 // When the catalog is updated we want to recreate the catalog layer
@@ -49,12 +74,20 @@ watch(() => props.catalog, () => createCatalogLayer())
 
 // update url property of the ImageOverlay Layer or create it
 watch(() => analysisStore.imageUrl, (newImageUrl) => {
+  if (!newImageUrl || !imageMap) return
+
   imageOverlay ? imageOverlay.setUrl(newImageUrl) : initImageOverlay(newImageUrl)
 })
 
 // Creates image overlay and sets bounds
 async function initImageOverlay(imgSrc) {
+  if (!imgSrc || !imageMap) return
+
+  const instanceId = viewerInstanceId
   const img = await loadImage(imgSrc)
+
+  if (instanceId !== viewerInstanceId || !imageMap) return
+
   imageDimensions.value = { width: img.width, height: img.height }
 
   // Fetch catalog only if empty
@@ -77,6 +110,8 @@ async function initImageOverlay(imgSrc) {
    * Next tick is used here otherwise the bounds will update before the ImageOverlay is added to the map
    */
   nextTick(() => {
+    if (!imageMap) return
+
     imageMap.invalidateSize()
     imageMap.fitBounds(imageBounds)
     imageMap.setMaxBounds(imageBounds)
@@ -199,6 +234,10 @@ function requestLineProfile(latLngs) {
 
 // When we get the catalog data this creates a layer of circles on the map
 function createCatalogLayer(){
+  if (!imageMap || !Array.isArray(props.catalog) || !props.catalog.length) {
+    return
+  }
+
   // Function to create a marker for a source
   function createSourceMarker(source){
     // Marker popup text
@@ -254,7 +293,23 @@ function createCatalogLayer(){
   </div>
 </template>
 <style>
+
 /* Custom icons for leaflet-geoman */
+.leaflet-top.leaflet-left{
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: wrap;
+  width: max-content;
+  max-width: calc(100% - 1rem);
+  margin: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+.leaflet-control-zoom {
+  display: flex;
+  flex-direction: row-reverse
+}
+
 .custom-reset-zoom-icon {
   background-image: url('../../assets/images/resize.svg');
   filter: invert(1);
@@ -285,6 +340,15 @@ function createCatalogLayer(){
   color: var(--disabled-text);
 }
 
+.leaflet-top.leaflet-left .leaflet-pm-toolbar.leaflet-bar a {
+  border-bottom: none;
+  border-right: 1px solid var(--secondary-background);
+}
+
+.leaflet-top.leaflet-left .leaflet-pm-toolbar.leaflet-bar a:last-child {
+  border-right: none;
+}
+
 .button-container .leaflet-pm-actions-container .leaflet-pm-action:hover{
   background-color: var(--secondary-interactive);
 }
@@ -299,6 +363,4 @@ function createCatalogLayer(){
   border-radius: 0.25rem;
 }
 
-</style>
-<style scoped>
 </style>

--- a/src/components/Analysis/ViewMode.vue
+++ b/src/components/Analysis/ViewMode.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { ref, watch } from 'vue'
+
+const emit = defineEmits(['updateCurrentIndex'])
+
+const props = defineProps({
+  currentIndex: {
+    type: Number,
+    required: true
+  },
+  images: {
+    type: Array,
+    required: true
+  }
+})
+
+const imageUrl = ref(null)
+const loading = ref(false)
+
+async function fetchThumbnail(basename) {
+  loading.value = true
+  try {
+    const response = await fetch(`https://archive-api.lco.global/thumbnails/?frame_basename=${basename}&size=large`)
+    const json = await response.json()
+    imageUrl.value = json.results?.[0]?.url || null
+  } catch (e) {
+    imageUrl.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.currentIndex, (newIndex) => {
+  const basename = props.images[newIndex]?.basename
+  if (basename) fetchThumbnail(basename)
+  else imageUrl.value = null
+}, { immediate: true })
+
+function showPrev() {
+  if (props.currentIndex > 0) {
+    emit('updateCurrentIndex', props.currentIndex - 1)
+  }
+}
+function showNext() {
+  if (props.currentIndex < props.images.length - 1) {
+    emit('updateCurrentIndex', props.currentIndex + 1)
+  }
+}
+</script>
+
+<template>
+  <div class="viewmode-container">
+    <v-btn
+      icon="mdi-chevron-left"
+      :disabled="props.currentIndex === 0"
+      @click="showPrev"
+    />
+    <div class="image-wrapper">
+      <v-progress-circular
+        v-if="loading"
+        indeterminate
+        color="primary"
+      />
+      <img
+        v-else-if="imageUrl"
+        crossorigin="anonymous"
+        :src="imageUrl"
+        alt="Thumbnail"
+        class="thumbnail-img"
+      >
+      <div
+        v-else
+        class="no-image"
+      >
+        No image available
+      </div>
+    </div>
+    <v-btn
+      icon="mdi-chevron-right"
+      :disabled="props.currentIndex === props.images.length - 1"
+      @click="showNext"
+    />
+  </div>
+</template>
+
+<style scoped>
+.viewmode-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+}
+.image-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+}
+.thumbnail-img {
+  max-width: 100%;
+  max-height: 80vh;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+.no-image {
+  color: var(--text);
+  font-size: 1.2rem;
+  text-align: center;
+}
+</style>

--- a/src/components/Analysis/ViewMode.vue
+++ b/src/components/Analysis/ViewMode.vue
@@ -9,14 +9,6 @@ const props = defineProps({
   image: {
     type: Object,
     required: true
-  },
-  hasPrevious: {
-    type: Boolean,
-    default: false
-  },
-  hasNext: {
-    type: Boolean,
-    default: false
   }
 })
 
@@ -65,14 +57,10 @@ watch(() => props.image, (image) => {
 }, { deep: true, immediate: true })
 
 function showPrev() {
-  if (props.hasPrevious) {
-    emit('previous')
-  }
+  emit('previous')
 }
 function showNext() {
-  if (props.hasNext) {
-    emit('next')
-  }
+  emit('next')
 }
 
 function handleTouchStart(event) {
@@ -113,7 +101,7 @@ async function handleImageError() {
   )
 }
 
-function handleImageLoad() {
+function doneLoadingImage() {
   loading.value = false
 }
 </script>
@@ -122,7 +110,6 @@ function handleImageLoad() {
   <div class="viewmode-container">
     <v-btn
       icon="mdi-chevron-left"
-      :disabled="!props.hasPrevious"
       @click="showPrev"
     />
     <div
@@ -143,7 +130,7 @@ function handleImageLoad() {
         alt="Thumbnail"
         class="thumbnail-img"
         :class="{ 'thumbnail-img--loading': loading }"
-        @load="handleImageLoad"
+        @load="doneLoadingImage"
         @error="handleImageError"
       >
       <div
@@ -155,7 +142,6 @@ function handleImageLoad() {
     </div>
     <v-btn
       icon="mdi-chevron-right"
-      :disabled="!props.hasNext"
       @click="showNext"
     />
   </div>

--- a/src/components/Analysis/ViewMode.vue
+++ b/src/components/Analysis/ViewMode.vue
@@ -1,50 +1,120 @@
 <script setup>
 import { ref, watch } from 'vue'
+import { useThumbnailsStore } from '@/stores/thumbnails'
+import { useConfigurationStore } from '@/stores/configuration'
 
-const emit = defineEmits(['updateCurrentIndex'])
+const emit = defineEmits(['previous', 'next'])
 
 const props = defineProps({
-  currentIndex: {
-    type: Number,
+  image: {
+    type: Object,
     required: true
   },
-  images: {
-    type: Array,
-    required: true
+  hasPrevious: {
+    type: Boolean,
+    default: false
+  },
+  hasNext: {
+    type: Boolean,
+    default: false
   }
 })
 
 const imageUrl = ref(null)
 const loading = ref(false)
+const touchStartX = ref(null)
+const retryingBasename = ref('')
+const thumbnailsStore = useThumbnailsStore()
+const configurationStore = useConfigurationStore()
 
-async function fetchThumbnail(basename) {
+function imageArchiveSource(image) {
+  if (image?.source && image.source !== 'archive') {
+    return image.source
+  }
+  return configurationStore.archiveType
+}
+
+async function fetchThumbnail(image) {
   loading.value = true
   try {
-    const response = await fetch(`https://archive-api.lco.global/thumbnails/?frame_basename=${basename}&size=large`)
-    const json = await response.json()
-    imageUrl.value = json.results?.[0]?.url || null
+    if (image?.largeCachedUrl) {
+      imageUrl.value = image.largeCachedUrl
+      return
+    }
+
+    const url = image?.large_url || image?.largeThumbUrl || ''
+    imageUrl.value = await thumbnailsStore.cacheImage(
+      'large',
+      imageArchiveSource(image),
+      url,
+      image?.basename || '',
+    )
   } catch (e) {
     imageUrl.value = null
   } finally {
-    loading.value = false
+    if (!imageUrl.value) {
+      loading.value = false
+    }
   }
 }
 
-watch(() => props.currentIndex, (newIndex) => {
-  const basename = props.images[newIndex]?.basename
-  if (basename) fetchThumbnail(basename)
+watch(() => props.image, (image) => {
+  retryingBasename.value = ''
+  if (image?.basename) fetchThumbnail(image)
   else imageUrl.value = null
-}, { immediate: true })
+}, { deep: true, immediate: true })
 
 function showPrev() {
-  if (props.currentIndex > 0) {
-    emit('updateCurrentIndex', props.currentIndex - 1)
+  if (props.hasPrevious) {
+    emit('previous')
   }
 }
 function showNext() {
-  if (props.currentIndex < props.images.length - 1) {
-    emit('updateCurrentIndex', props.currentIndex + 1)
+  if (props.hasNext) {
+    emit('next')
   }
+}
+
+function handleTouchStart(event) {
+  touchStartX.value = event.changedTouches[0]?.clientX ?? null
+}
+
+function handleTouchEnd(event) {
+  if (touchStartX.value == null) return
+
+  const touchEndX = event.changedTouches[0]?.clientX ?? touchStartX.value
+  const deltaX = touchEndX - touchStartX.value
+  touchStartX.value = null
+
+  if (Math.abs(deltaX) < 40) return
+
+  if (deltaX < 0) {
+    showNext()
+  } else {
+    showPrev()
+  }
+}
+
+async function handleImageError() {
+  if (!props.image?.basename || retryingBasename.value === props.image.basename) {
+    imageUrl.value = null
+    return
+  }
+
+  retryingBasename.value = props.image.basename
+  thumbnailsStore.invalidateCachedImage('large', props.image.basename)
+
+  const url = props.image?.large_url || props.image?.largeThumbUrl || ''
+  imageUrl.value = await thumbnailsStore.cacheImage(
+    'large',
+    imageArchiveSource(props.image),
+    url,
+    props.image.basename,
+  )
+}
+
+function handleImageLoad() {
+  loading.value = false
 }
 </script>
 
@@ -52,21 +122,29 @@ function showNext() {
   <div class="viewmode-container">
     <v-btn
       icon="mdi-chevron-left"
-      :disabled="props.currentIndex === 0"
+      :disabled="!props.hasPrevious"
       @click="showPrev"
     />
-    <div class="image-wrapper">
+    <div
+      class="image-wrapper"
+      @touchstart.passive="handleTouchStart"
+      @touchend.passive="handleTouchEnd"
+    >
       <v-progress-circular
         v-if="loading"
         indeterminate
         color="primary"
+        class="image-loading-spinner"
       />
       <img
-        v-else-if="imageUrl"
+        v-if="imageUrl"
         crossorigin="anonymous"
         :src="imageUrl"
         alt="Thumbnail"
         class="thumbnail-img"
+        :class="{ 'thumbnail-img--loading': loading }"
+        @load="handleImageLoad"
+        @error="handleImageError"
       >
       <div
         v-else
@@ -77,7 +155,7 @@ function showNext() {
     </div>
     <v-btn
       icon="mdi-chevron-right"
-      :disabled="props.currentIndex === props.images.length - 1"
+      :disabled="!props.hasNext"
       @click="showNext"
     />
   </div>
@@ -98,12 +176,19 @@ function showNext() {
   align-items: center;
   justify-content: center;
   min-height: 400px;
+  position: relative;
 }
 .thumbnail-img {
   max-width: 100%;
   max-height: 80vh;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+.thumbnail-img--loading {
+  visibility: hidden;
+}
+.image-loading-spinner {
+  position: absolute;
 }
 .no-image {
   color: var(--text);

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -287,7 +287,6 @@ watch(
         </v-col>
         <operation-output-grid
           :operation-outputs="filteredImages"
-          :images="sortByObservationDate(props.data.input_data)"
           :column-span="calculateColumnSpan(filteredImages.length, IMAGES_PER_ROW)"
         />
       </v-container>

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -24,8 +24,14 @@ const props = defineProps({
 const store = useConfigurationStore()
 const alertStore = useAlertsStore()
 
+function sortByObservationDate(items) {
+  return [...items].sort((a, b) => {
+    return new Date(a.observation_date) - new Date(b.observation_date)
+  })
+}
+
 const operations = ref([...props.data.operations])
-const items = ref([...props.data.input_data])
+const items = ref(sortByObservationDate(props.data.input_data))
 const showWizardDialog = ref(false)
 const tab = ref('main')
 const operationPollingTimers = {}
@@ -39,9 +45,9 @@ var operationMap = {}
 // When a user clicks on an operation, we filter to only show the outputs of that operation
 const filteredImages = computed(() => {
   if (selectedOperation.value === -1) {
-    return items.value
+    return sortByObservationDate(items.value)
   } else {
-    return items.value.filter(item => item.operation === selectedOperation.value)
+    return sortByObservationDate(items.value.filter(item => item.operation === selectedOperation.value))
   }
 })
 

--- a/src/components/DataSession/DataSession.vue
+++ b/src/components/DataSession/DataSession.vue
@@ -287,6 +287,7 @@ watch(
         </v-col>
         <operation-output-grid
           :operation-outputs="filteredImages"
+          :images="sortByObservationDate(props.data.input_data)"
           :column-span="calculateColumnSpan(filteredImages.length, IMAGES_PER_ROW)"
         />
       </v-container>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -37,15 +37,6 @@ const showAnalysisDialog = ref(false)
 const imageDetails = ref({})
 const analysisImage = ref({})
 
-function getAnalysisImage(image) {
-  const currentIndex = props.images.findIndex((candidate) => candidate.basename === image?.basename)
-  return {
-    ...image,
-    hasPrevious: currentIndex > 0,
-    hasNext: currentIndex > -1 && currentIndex < props.images.length - 1,
-  }
-}
-
 function imageArchiveSource(image) {
   if (image?.source && image.source !== 'archive') {
     return image.source
@@ -68,7 +59,7 @@ const launchAnalysis = async (image) => {
   alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   try {
     await ensureLargeCachedUrl(image)
-    analysisImage.value = getAnalysisImage(image)
+    analysisImage.value = image
     showAnalysisDialog.value = true
   } catch {
     alertsStore.setAlert('error', `Failed to open ${image?.basename}`)
@@ -76,15 +67,16 @@ const launchAnalysis = async (image) => {
 }
 
 async function showAdjacentImage(direction) {
+  if (!props.images.length) return
+
   const currentIndex = props.images.findIndex((image) => image.basename === analysisImage.value?.basename)
   if (currentIndex < 0) return
 
-  const nextIndex = currentIndex + direction
+  const nextIndex = (currentIndex + direction + props.images.length) % props.images.length
   const nextImage = props.images[nextIndex]
-  if (!nextImage) return
 
   await ensureLargeCachedUrl(nextImage)
-  analysisImage.value = getAnalysisImage(nextImage)
+  analysisImage.value = nextImage
 }
 
 const isSelected = (basename) => {

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -37,11 +37,30 @@ const showAnalysisDialog = ref(false)
 const imageDetails = ref({})
 const analysisImage = ref({})
 
-async function ensureLargeCachedUrl(image) {
-  if (!image.largeCachedUrl) {
-    const url = image.large_url || image.largeThumbUrl || ''
-    image.largeCachedUrl = await thumbnailsStore.cacheImage('large', configurationStore.archiveType, url, image.basename)
+function getAnalysisImage(image) {
+  const currentIndex = props.images.findIndex((candidate) => candidate.basename === image?.basename)
+  return {
+    ...image,
+    hasPrevious: currentIndex > 0,
+    hasNext: currentIndex > -1 && currentIndex < props.images.length - 1,
   }
+}
+
+function imageArchiveSource(image) {
+  if (image?.source && image.source !== 'archive') {
+    return image.source
+  }
+  return configurationStore.archiveType
+}
+
+async function ensureLargeCachedUrl(image) {
+  const url = image.large_url || image.largeThumbUrl || ''
+  image.largeCachedUrl = await thumbnailsStore.cacheImage(
+    'large',
+    imageArchiveSource(image),
+    url,
+    image.basename,
+  )
   return image.largeCachedUrl
 }
 
@@ -49,11 +68,23 @@ const launchAnalysis = async (image) => {
   alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   try {
     await ensureLargeCachedUrl(image)
-    analysisImage.value = image
+    analysisImage.value = getAnalysisImage(image)
     showAnalysisDialog.value = true
   } catch {
     alertsStore.setAlert('error', `Failed to open ${image?.basename}`)
   }
+}
+
+async function showAdjacentImage(direction) {
+  const currentIndex = props.images.findIndex((image) => image.basename === analysisImage.value?.basename)
+  if (currentIndex < 0) return
+
+  const nextIndex = currentIndex + direction
+  const nextImage = props.images[nextIndex]
+  if (!nextImage) return
+
+  await ensureLargeCachedUrl(nextImage)
+  analysisImage.value = getAnalysisImage(nextImage)
 }
 
 const isSelected = (basename) => {
@@ -99,8 +130,9 @@ watch(() => props.images, () => {
   >
     <image-analysis-view
       :image="analysisImage"
-      :images="props.images"
       @close-analysis-dialog="showAnalysisDialog = false"
+      @request-previous-image="showAdjacentImage(-1)"
+      @request-next-image="showAdjacentImage(1)"
     />
   </v-dialog>
 </template>

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
+import { ensureLargeCachedUrl } from '@/utils/common'
 import ThumbnailImage from '@/components/Global/ThumbnailImage.vue'
 import ImageAnalysisView from '../../views/ImageAnalysisView.vue'
 
@@ -37,28 +38,10 @@ const showAnalysisDialog = ref(false)
 const imageDetails = ref({})
 const analysisImage = ref({})
 
-function imageArchiveSource(image) {
-  if (image?.source && image.source !== 'archive') {
-    return image.source
-  }
-  return configurationStore.archiveType
-}
-
-async function ensureLargeCachedUrl(image) {
-  const url = image.large_url || image.largeThumbUrl || ''
-  image.largeCachedUrl = await thumbnailsStore.cacheImage(
-    'large',
-    imageArchiveSource(image),
-    url,
-    image.basename,
-  )
-  return image.largeCachedUrl
-}
-
 const launchAnalysis = async (image) => {
   alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   try {
-    await ensureLargeCachedUrl(image)
+    await ensureLargeCachedUrl(image, thumbnailsStore.cacheImage, configurationStore.archiveType)
     analysisImage.value = image
     showAnalysisDialog.value = true
   } catch {
@@ -75,7 +58,7 @@ async function showAdjacentImage(direction) {
   const nextIndex = (currentIndex + direction + props.images.length) % props.images.length
   const nextImage = props.images[nextIndex]
 
-  await ensureLargeCachedUrl(nextImage)
+  await ensureLargeCachedUrl(nextImage, thumbnailsStore.cacheImage, configurationStore.archiveType)
   analysisImage.value = nextImage
 }
 

--- a/src/components/Global/ImageGrid.vue
+++ b/src/components/Global/ImageGrid.vue
@@ -99,6 +99,7 @@ watch(() => props.images, () => {
   >
     <image-analysis-view
       :image="analysisImage"
+      :images="props.images"
       @close-analysis-dialog="showAnalysisDialog = false"
     />
   </v-dialog>

--- a/src/components/Global/OperationOutputGrid.vue
+++ b/src/components/Global/OperationOutputGrid.vue
@@ -13,6 +13,10 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
+  images: {
+    type: Array,
+    default: () => []
+  },
   columnSpan: {
     type: Number,
     required: true
@@ -35,7 +39,7 @@ const analysisData = ref({})
 
 async function ensureLargeCachedUrl(image) {
   if (!image.largeCachedUrl) {
-    const url = image.large_url || image.largeThumbUrl || ''
+    const url = image.url || image.large_url || image.largeThumbUrl || ''
     image.largeCachedUrl = await thumbnailsStore.cacheImage('large', configurationStore.archiveType, url, image.basename)
   }
   return image.largeCachedUrl
@@ -111,6 +115,7 @@ watch(() => props.operationOutputs, () => {
   >
     <image-analysis-view
       :image="analysisImage"
+      :images="props.images"
       @close-analysis-dialog="showImageAnalysisDialog = false"
     />
   </v-dialog>

--- a/src/components/Global/OperationOutputGrid.vue
+++ b/src/components/Global/OperationOutputGrid.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
@@ -10,10 +10,6 @@ import DataAnalysisView from '@/views/DataAnalysisView.vue'
 
 const props = defineProps({
   operationOutputs: {
-    type: Array,
-    default: () => []
-  },
-  images: {
     type: Array,
     default: () => []
   },
@@ -37,12 +33,16 @@ const imageDetails = ref({})
 const analysisImage = ref({})
 const analysisData = ref({})
 
+const imageOperationOutputs = computed(() => {
+  return props.operationOutputs.filter((operationOutput) => isImage(operationOutput))
+})
+
 function getAnalysisImage(image) {
-  const currentIndex = props.images.findIndex((candidate) => candidate.basename === image?.basename)
+  const currentIndex = imageOperationOutputs.value.findIndex((candidate) => candidate.basename === image?.basename)
   return {
     ...image,
     hasPrevious: currentIndex > 0,
-    hasNext: currentIndex > -1 && currentIndex < props.images.length - 1,
+    hasNext: currentIndex > -1 && currentIndex < imageOperationOutputs.value.length - 1,
   }
 }
 
@@ -88,10 +88,10 @@ function isImage(operationOutput) {
 }
 
 async function showAdjacentImage(direction) {
-  const currentIndex = props.images.findIndex((image) => image.basename === analysisImage.value?.basename)
+  const currentIndex = imageOperationOutputs.value.findIndex((image) => image.basename === analysisImage.value?.basename)
   if (currentIndex < 0) return
 
-  const nextImage = props.images[currentIndex + direction]
+  const nextImage = imageOperationOutputs.value[currentIndex + direction]
   if (!nextImage) return
 
   await ensureLargeCachedUrl(nextImage)

--- a/src/components/Global/OperationOutputGrid.vue
+++ b/src/components/Global/OperationOutputGrid.vue
@@ -37,15 +37,6 @@ const imageOperationOutputs = computed(() => {
   return props.operationOutputs.filter((operationOutput) => isImage(operationOutput))
 })
 
-function getAnalysisImage(image) {
-  const currentIndex = imageOperationOutputs.value.findIndex((candidate) => candidate.basename === image?.basename)
-  return {
-    ...image,
-    hasPrevious: currentIndex > 0,
-    hasNext: currentIndex > -1 && currentIndex < imageOperationOutputs.value.length - 1,
-  }
-}
-
 function imageArchiveSource(image) {
   if (image?.source && image.source !== 'archive') {
     return image.source
@@ -68,7 +59,7 @@ const launchAnalysis = async (image) => {
   alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   try {
     await ensureLargeCachedUrl(image)
-    analysisImage.value = getAnalysisImage(image)
+    analysisImage.value = image
     showImageAnalysisDialog.value = true
   } catch {
     alertsStore.setAlert('error', `Failed to open ${image?.basename}`)
@@ -88,14 +79,17 @@ function isImage(operationOutput) {
 }
 
 async function showAdjacentImage(direction) {
-  const currentIndex = imageOperationOutputs.value.findIndex((image) => image.basename === analysisImage.value?.basename)
+  const images = imageOperationOutputs.value
+  if (!images.length) return
+
+  const currentIndex = images.findIndex((image) => image.basename === analysisImage.value?.basename)
   if (currentIndex < 0) return
 
-  const nextImage = imageOperationOutputs.value[currentIndex + direction]
-  if (!nextImage) return
+  const nextIndex = (currentIndex + direction + images.length) % images.length
+  const nextImage = images[nextIndex]
 
   await ensureLargeCachedUrl(nextImage)
-  analysisImage.value = getAnalysisImage(nextImage)
+  analysisImage.value = nextImage
 }
 
 watch(() => props.operationOutputs, () => {

--- a/src/components/Global/OperationOutputGrid.vue
+++ b/src/components/Global/OperationOutputGrid.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAlertsStore } from '@/stores/alerts'
+import { ensureLargeCachedUrl } from '@/utils/common'
 import ThumbnailImage from '@/components/Global/ThumbnailImage.vue'
 import DataOutput from '@/components/Global/DataOutput.vue'
 import ImageAnalysisView from '@/views/ImageAnalysisView.vue'
@@ -37,28 +38,10 @@ const imageOperationOutputs = computed(() => {
   return props.operationOutputs.filter((operationOutput) => isImage(operationOutput))
 })
 
-function imageArchiveSource(image) {
-  if (image?.source && image.source !== 'archive') {
-    return image.source
-  }
-  return configurationStore.archiveType
-}
-
-async function ensureLargeCachedUrl(image) {
-  const url = image.large_url || image.largeThumbUrl || ''
-  image.largeCachedUrl = await thumbnailsStore.cacheImage(
-    'large',
-    imageArchiveSource(image),
-    url,
-    image.basename,
-  )
-  return image.largeCachedUrl
-}
-
 const launchAnalysis = async (image) => {
   alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   try {
-    await ensureLargeCachedUrl(image)
+    await ensureLargeCachedUrl(image, thumbnailsStore.cacheImage, configurationStore.archiveType)
     analysisImage.value = image
     showImageAnalysisDialog.value = true
   } catch {
@@ -88,7 +71,7 @@ async function showAdjacentImage(direction) {
   const nextIndex = (currentIndex + direction + images.length) % images.length
   const nextImage = images[nextIndex]
 
-  await ensureLargeCachedUrl(nextImage)
+  await ensureLargeCachedUrl(nextImage, thumbnailsStore.cacheImage, configurationStore.archiveType)
   analysisImage.value = nextImage
 }
 

--- a/src/components/Global/OperationOutputGrid.vue
+++ b/src/components/Global/OperationOutputGrid.vue
@@ -37,11 +37,30 @@ const imageDetails = ref({})
 const analysisImage = ref({})
 const analysisData = ref({})
 
-async function ensureLargeCachedUrl(image) {
-  if (!image.largeCachedUrl) {
-    const url = image.url || image.large_url || image.largeThumbUrl || ''
-    image.largeCachedUrl = await thumbnailsStore.cacheImage('large', configurationStore.archiveType, url, image.basename)
+function getAnalysisImage(image) {
+  const currentIndex = props.images.findIndex((candidate) => candidate.basename === image?.basename)
+  return {
+    ...image,
+    hasPrevious: currentIndex > 0,
+    hasNext: currentIndex > -1 && currentIndex < props.images.length - 1,
   }
+}
+
+function imageArchiveSource(image) {
+  if (image?.source && image.source !== 'archive') {
+    return image.source
+  }
+  return configurationStore.archiveType
+}
+
+async function ensureLargeCachedUrl(image) {
+  const url = image.large_url || image.largeThumbUrl || ''
+  image.largeCachedUrl = await thumbnailsStore.cacheImage(
+    'large',
+    imageArchiveSource(image),
+    url,
+    image.basename,
+  )
   return image.largeCachedUrl
 }
 
@@ -49,7 +68,7 @@ const launchAnalysis = async (image) => {
   alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
   try {
     await ensureLargeCachedUrl(image)
-    analysisImage.value = image
+    analysisImage.value = getAnalysisImage(image)
     showImageAnalysisDialog.value = true
   } catch {
     alertsStore.setAlert('error', `Failed to open ${image?.basename}`)
@@ -66,6 +85,17 @@ function isImage(operationOutput) {
     return true
   }
   return false
+}
+
+async function showAdjacentImage(direction) {
+  const currentIndex = props.images.findIndex((image) => image.basename === analysisImage.value?.basename)
+  if (currentIndex < 0) return
+
+  const nextImage = props.images[currentIndex + direction]
+  if (!nextImage) return
+
+  await ensureLargeCachedUrl(nextImage)
+  analysisImage.value = getAnalysisImage(nextImage)
 }
 
 watch(() => props.operationOutputs, () => {
@@ -115,8 +145,9 @@ watch(() => props.operationOutputs, () => {
   >
     <image-analysis-view
       :image="analysisImage"
-      :images="props.images"
       @close-analysis-dialog="showImageAnalysisDialog = false"
+      @request-previous-image="showAdjacentImage(-1)"
+      @request-next-image="showAdjacentImage(1)"
     />
   </v-dialog>
   <v-dialog

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -34,15 +34,6 @@ const alertsStore = useAlertsStore()
 const thumbnailsStore = useThumbnailsStore()
 const configurationStore = useConfigurationStore()
 
-function getAnalysisImage(image) {
-  const currentIndex = props.images.findIndex((candidate) => candidate.basename === image?.basename)
-  return {
-    ...image,
-    hasPrevious: currentIndex > 0,
-    hasNext: currentIndex > -1 && currentIndex < props.images.length - 1,
-  }
-}
-
 function imageArchiveSource(image) {
   if (image?.source && image.source !== 'archive') {
     return image.source
@@ -73,7 +64,7 @@ async function launchAnalysis(image){
   try {
     alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
     await ensureLargeCachedUrl(image)
-    analysisImage.value = getAnalysisImage(image)
+    analysisImage.value = image
     showAnalysisDialog.value = true
   } catch (error) {
     console.error(error)
@@ -82,11 +73,13 @@ async function launchAnalysis(image){
 }
 
 function showAdjacentImage(direction){
+  if (!props.images.length) return
+
   const currentIndex = props.images.findIndex((image) => image.basename === analysisImage.value?.basename)
   if (currentIndex < 0) return
 
-  const nextImage = props.images[currentIndex + direction]
-  if (!nextImage) return
+  const nextIndex = (currentIndex + direction + props.images.length) % props.images.length
+  const nextImage = props.images[nextIndex]
 
   launchAnalysis(nextImage)
 }

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -34,6 +34,22 @@ const alertsStore = useAlertsStore()
 const thumbnailsStore = useThumbnailsStore()
 const configurationStore = useConfigurationStore()
 
+function getAnalysisImage(image) {
+  const currentIndex = props.images.findIndex((candidate) => candidate.basename === image?.basename)
+  return {
+    ...image,
+    hasPrevious: currentIndex > 0,
+    hasNext: currentIndex > -1 && currentIndex < props.images.length - 1,
+  }
+}
+
+function imageArchiveSource(image) {
+  if (image?.source && image.source !== 'archive') {
+    return image.source
+  }
+  return configurationStore.archiveType
+}
+
 // checks difference between table and parent selected images and emits the difference
 function select(tableModel){
   const symDiffSelected = tableModel.filter(image => !props.selectedImages.includes(image)).concat(props.selectedImages.filter(image => !tableModel.includes(image)))
@@ -42,26 +58,37 @@ function select(tableModel){
   }
 }
 
-function launchAnalysis(image){
+async function ensureLargeCachedUrl(image) {
+  const url = image.large_url || image.largeThumbUrl || ''
+  image.largeCachedUrl = await thumbnailsStore.cacheImage(
+    'large',
+    imageArchiveSource(image),
+    url,
+    image.basename,
+  )
+  return image.largeCachedUrl
+}
+
+async function launchAnalysis(image){
   try {
     alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
-    if (!image.largeCachedUrl) {
-      image.largeCachedUrl = ref('')
-      const url = image.large_url || image.largeThumbUrl || ''
-      thumbnailsStore.cacheImage('large', configurationStore.archiveType, url, image.basename).then((cachedUrl) => {
-        image.largeCachedUrl = cachedUrl
-        analysisImage.value = image
-        showAnalysisDialog.value = true
-      })
-    }
-    else {
-      analysisImage.value = image
-      showAnalysisDialog.value = true
-    }
+    await ensureLargeCachedUrl(image)
+    analysisImage.value = getAnalysisImage(image)
+    showAnalysisDialog.value = true
   } catch (error) {
     console.error(error)
     alertsStore.setAlert('error', `Failed to open ${image?.basename}`)
   }
+}
+
+function showAdjacentImage(direction){
+  const currentIndex = props.images.findIndex((image) => image.basename === analysisImage.value?.basename)
+  if (currentIndex < 0) return
+
+  const nextImage = props.images[currentIndex + direction]
+  if (!nextImage) return
+
+  launchAnalysis(nextImage)
 }
 
 </script>
@@ -122,8 +149,9 @@ function launchAnalysis(image){
   >
     <image-analyzer
       :image="analysisImage"
-      :images="props.images"
       @close-analysis-dialog="showAnalysisDialog = false"
+      @request-previous-image="showAdjacentImage(-1)"
+      @request-next-image="showAdjacentImage(1)"
     />
   </v-dialog>
 </template>

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -122,6 +122,7 @@ function launchAnalysis(image){
   >
     <image-analyzer
       :image="analysisImage"
+      :images="props.images"
       @close-analysis-dialog="showAnalysisDialog = false"
     />
   </v-dialog>

--- a/src/components/Project/ImageList.vue
+++ b/src/components/Project/ImageList.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useThumbnailsStore } from '@/stores/thumbnails'
 import { useAlertsStore } from '@/stores/alerts'
 import { useConfigurationStore } from '@/stores/configuration'
-import { siteIDToName } from '@/utils/common'
+import { ensureLargeCachedUrl, siteIDToName } from '@/utils/common'
 import FilterBadge from '@/components/Global/FilterBadge.vue'
 import ImageAnalyzer from '../../views/ImageAnalysisView.vue'
 
@@ -34,13 +34,6 @@ const alertsStore = useAlertsStore()
 const thumbnailsStore = useThumbnailsStore()
 const configurationStore = useConfigurationStore()
 
-function imageArchiveSource(image) {
-  if (image?.source && image.source !== 'archive') {
-    return image.source
-  }
-  return configurationStore.archiveType
-}
-
 // checks difference between table and parent selected images and emits the difference
 function select(tableModel){
   const symDiffSelected = tableModel.filter(image => !props.selectedImages.includes(image)).concat(props.selectedImages.filter(image => !tableModel.includes(image)))
@@ -49,21 +42,10 @@ function select(tableModel){
   }
 }
 
-async function ensureLargeCachedUrl(image) {
-  const url = image.large_url || image.largeThumbUrl || ''
-  image.largeCachedUrl = await thumbnailsStore.cacheImage(
-    'large',
-    imageArchiveSource(image),
-    url,
-    image.basename,
-  )
-  return image.largeCachedUrl
-}
-
 async function launchAnalysis(image){
   try {
     alertsStore.setAlert('info', `Opening ${image?.basename} for analysis`)
-    await ensureLargeCachedUrl(image)
+    await ensureLargeCachedUrl(image, thumbnailsStore.cacheImage, configurationStore.archiveType)
     analysisImage.value = image
     showAnalysisDialog.value = true
   } catch (error) {

--- a/src/stores/analysis.js
+++ b/src/stores/analysis.js
@@ -66,9 +66,9 @@ export const useAnalysisStore = defineStore('analysis', {
     },
     loadImageDimensions(url) {
       const img = new Image()
-      img.src = url
 
       return new Promise((resolve) => {
+        img.src = url
         img.onload = () => {
           this.imageWidth = Math.min(img.width, MAX_IMAGE_DIMENSION)
           this.imageHeight = Math.min(img.height, MAX_IMAGE_DIMENSION)

--- a/src/stores/thumbnails.js
+++ b/src/stores/thumbnails.js
@@ -108,6 +108,12 @@ export const useThumbnailsStore = defineStore('thumbnails', {
     setArchives(archives) {
       this.archives = archives
     },
+    invalidateCachedImage(size, basename, persist=true) {
+      basename = basename.replace(/-(small|large)/, '')
+      const cache = size === 'large' ? this.largeThumbnailsCache : this.smallThumbnailsCache
+      cache.delete(basename)
+      if (persist) this.$persist()
+    },
     async cacheImage(size, archive, url, basename, persist=true) {
       basename = basename.replace(/-(small|large)/, '')
     

--- a/src/stores/userData.js
+++ b/src/stores/userData.js
@@ -17,6 +17,7 @@ export const useUserDataStore = defineStore('userData', {
       gridToggle: true,
       coordsToggle: true,
       catalogToggle: true,
+      imageDisplayMode: 'Analysis Mode',
       activeSessionId: ''
     }
   },

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -37,6 +37,11 @@ function scalePoint(width1, height1, width2, height2, x, y){
   }
 }
 
+function basenameToSequence(basename = '') {
+  const match = basename.match(/^[^-]+-[^-]+-[^-]+-([^-]+)-e91$/)
+  return match?.[1] || 'Unknown'
+}
+
 // Utility function to load an image
 function loadImage(src) {
   return new Promise((resolve, reject) => {
@@ -47,4 +52,4 @@ function loadImage(src) {
   })
 }
 
-export { calculateColumnSpan, siteIDToName, initializeDate, loadImage, scalePoint }
+export { calculateColumnSpan, siteIDToName, initializeDate, loadImage, scalePoint, basenameToSequence }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -42,6 +42,21 @@ function basenameToSequence(basename = '') {
   return match?.[1] || 'Unknown'
 }
 
+async function ensureLargeCachedUrl(image, cacheImage, archiveType) {
+  const imageArchiveSource = image?.source && image.source !== 'archive'
+    ? image.source
+    : archiveType
+  const url = image.large_url || image.largeThumbUrl || ''
+
+  image.largeCachedUrl = await cacheImage(
+    'large',
+    imageArchiveSource,
+    url,
+    image.basename,
+  )
+  return image.largeCachedUrl
+}
+
 // Utility function to load an image
 function loadImage(src) {
   return new Promise((resolve, reject) => {
@@ -52,4 +67,4 @@ function loadImage(src) {
   })
 }
 
-export { calculateColumnSpan, siteIDToName, initializeDate, loadImage, scalePoint, basenameToSequence }
+export { calculateColumnSpan, siteIDToName, initializeDate, loadImage, scalePoint, basenameToSequence, ensureLargeCachedUrl }

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -473,7 +473,6 @@ async function onModeChange(val) {
   </v-dialog>
 </template>
 <style scoped>
-/* Center the mode dropdown at the top */
 .mode-dropdown-center {
   display: flex;
   justify-content: center;

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -46,7 +46,7 @@ let imgWorkerProcessing = false
 let imgWorkerNextScale = null
 const touchStartX = ref(null)
 
-const selectedMode = ref('Analysis Mode')
+const selectedMode = ref(userDataStore.imageDisplayMode || 'Analysis Mode')
 const hasPrevious = computed(() => props.image?.hasPrevious === true)
 const hasNext = computed(() => props.image?.hasNext === true)
 
@@ -104,6 +104,10 @@ watch(() => props.image, async (image) => {
 
   selectedBasename.value = image.basename
   await loadActiveImage(image)
+})
+
+watch(selectedMode, (mode) => {
+  userDataStore.imageDisplayMode = mode
 })
 
 onUnmounted(() => {
@@ -318,19 +322,22 @@ async function onModeChange(val) {
 
 </script>
 <template>
-  <div class="mode-dropdown-center">
-    <select
-      v-model="selectedMode"
-      class="mode-dropdown native-dropdown"
-      @change="onModeChange($event.target.value)"
+  <div class="mode-toggle-center">
+    <v-btn-toggle
+      :model-value="selectedMode"
+      class="mode-toggle"
+      density="comfortable"
+      mandatory
+      rounded="lg"
+      @update:model-value="onModeChange"
     >
-      <option value="View Mode">
+      <v-btn value="View Mode">
         View Mode
-      </option>
-      <option value="Analysis Mode">
+      </v-btn>
+      <v-btn value="Analysis Mode">
         Analysis Mode
-      </option>
-    </select>
+      </v-btn>
+    </v-btn-toggle>
   </div>
   <v-sheet class="analysis-page">
     <v-toolbar
@@ -496,7 +503,7 @@ async function onModeChange(val) {
   </v-dialog>
 </template>
 <style scoped>
-.mode-dropdown-center {
+.mode-toggle-center {
   display: flex;
   justify-content: center;
   align-items: flex-start;
@@ -507,23 +514,17 @@ async function onModeChange(val) {
   z-index: 2100;
   pointer-events: none;
 }
-.mode-dropdown {
-  min-width: 120px;
-  max-width: 180px;
+.mode-toggle {
   pointer-events: auto;
-}
-.native-dropdown {
-  padding: 6px 16px;
-  border-radius: 6px;
-  border: 1px solid var(--primary-interactive, #1976d2);
-  background: var(--card-background, #fff);
-  color: var(--text, #222);
-  font-size: 15px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.07);
-  outline: none;
-  appearance: none;
-  margin: 0 auto;
-  display: block;
+}
+.mode-toggle :deep(.v-btn) {
+  background-color: var(--secondary-background);
+  color: var(--text);
+}
+.mode-toggle :deep(.v-btn--active) {
+  background-color: var(--primary-interactive);
+  color: var(--text);
 }
 /* Main Sections */
 .analysis-page{

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -1,9 +1,11 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { fetchApiCall } from '../utils/api'
+import { siteIDToName } from '@/utils/common'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAnalysisStore } from '@/stores/analysis'
 import { useUserDataStore } from '@/stores/userData'
+import { useThumbnailsStore } from '@/stores/thumbnails'
 import FilterBadge from '@/components/Global/FilterBadge.vue'
 import NonLinearSlider from '@/components/Global/NonLinearSlider.vue'
 import HistogramSlider from '@/components/Global/Scaling/HistogramSlider.vue'
@@ -11,6 +13,7 @@ import ImageDownloadMenu from '@/components/Global/ImageDownloadMenu.vue'
 import FitsHeaderTable from '@/components/Analysis/FitsHeaderTable.vue'
 import ImageViewer from '@/components/Analysis/ImageViewer.vue'
 import LinePlot from '@/components/Analysis/LinePlot.vue'
+import ViewMode from '@/components/Analysis/ViewMode.vue'
 import { getActivePinia } from 'pinia'
 
 const props = defineProps({
@@ -18,6 +21,10 @@ const props = defineProps({
     type: Object,
     required: true,
     default: null,
+  },
+  images: {
+    type: Array,
+    default: () => []
   }
 })
 
@@ -26,6 +33,7 @@ const emit = defineEmits(['closeAnalysisDialog'])
 const configStore = useConfigurationStore()
 const analysisStore = useAnalysisStore()
 const userDataStore = useUserDataStore()
+const thumbnailsStore = useThumbnailsStore()
 
 const lineProfile = ref([])
 const lineProfileLength = ref()
@@ -37,9 +45,19 @@ const fluxSliderRange = ref([0, 10000])
 const positionAngle = ref()
 const wcsSolution = ref()
 const showHeaderDialog = ref(false)
-const imgWorker = new Worker('drawImageWorker.js')
+const selectedBasename = ref(props.image?.basename || '')
+const activeImage = ref(props.image)
+let imgWorker = new Worker('drawImageWorker.js')
 let imgWorkerProcessing = false
 let imgWorkerNextScale = null
+
+const selectedMode = ref('Analysis Mode')
+
+const currentImageIndex = computed(() => {
+  if (!selectedBasename.value) return -1
+  return props.images.findIndex(image => image.basename === selectedBasename.value)
+})
+
 
 const filteredCatalog = computed(() => {
   if (!userDataStore.catalogToggle) {
@@ -52,33 +70,139 @@ const filteredCatalog = computed(() => {
 })
 
 const isFitsImage = computed(() => {
-  return props.image && (!('type' in props.image) || props.image?.type === 'fits')
+  return activeImage.value && (!('type' in activeImage.value) || activeImage.value?.type === 'fits')
 })
 
-onMounted(() => {
-  analysisStore.image = props.image
-  analysisStore.imageUrl = props.image.largeCachedUrl
-  if (isFitsImage.value) {
-    analysisStore.loadHeaderData()
-    instantiateScalerWorker()
+const basenameSequence = computed(() => {
+  const basename = activeImage.value?.basename || ''
+  const match = basename.match(/^[^-]+-[^-]+-[^-]+-([^-]+)-e91$/)
+
+  return match?.[1] || 'Unknown'
+})
+
+const headerChips = computed(() => {
+  const headerData = analysisStore.headerData
+
+  if (!headerData) {
+    return [
+      { icon: 'mdi-numeric', text: basenameSequence.value }
+    ]
   }
+
+  return [
+    { icon: 'mdi-earth', text: siteIDToName(headerData.SITEID) },
+    { icon: 'mdi-telescope', text: headerData.TELID },
+    { icon: 'mdi-camera', text: headerData.INSTRUME },
+    { icon: 'mdi-clock', text: new Date(headerData.DATE).toLocaleString() },
+    { icon: 'mdi-numeric', text: basenameSequence.value }
+  ]
+})
+
+const viewModeDetails = computed(() => {
+  const headerData = analysisStore.headerData || {}
+
+  return [
+    { label: 'RA', value: headerData.RA || 'Unknown' },
+    { label: 'Dec', value: headerData.DEC || 'Unknown' },
+    { label: 'Object', value: headerData.OBJECT || 'Unknown' }
+  ]
+})
+
+onMounted(async() => {
+  await loadActiveImage(resolveImageByBasename(selectedBasename.value) || props.image)
+})
+
+watch(() => props.image, async (image) => {
+  if (!image?.basename) return
+
+  selectedBasename.value = image.basename
+  await loadActiveImage(resolveImageByBasename(image.basename) || image)
 })
 
 onUnmounted(() => {
-  if (isFitsImage.value) {
-    imgWorker.terminate()
-  }
+  cleanupWorker()
   analysisStore.$dispose()
   delete getActivePinia().state.value[analysisStore.$id]
 })
+
+function cleanupWorker() {
+  if (imgWorker) {
+    imgWorker.terminate()
+    imgWorker = null
+  }
+}
+
+function resetAnalysisState() {
+  lineProfile.value = []
+  lineProfileLength.value = null
+  startCoords.value = null
+  endCoords.value = null
+  catalog.value = []
+  sideChart.value = ''
+  fluxSliderRange.value = [0, 10000]
+  positionAngle.value = null
+  wcsSolution.value = null
+  showHeaderDialog.value = false
+  imgWorkerProcessing = false
+  imgWorkerNextScale = null
+  analysisStore.headerData = null
+  analysisStore.rawData = null
+  analysisStore.zmin = null
+  analysisStore.zmax = null
+  analysisStore.imageWidth = null
+  analysisStore.imageHeight = null
+  analysisStore.imageScaleLoading = false
+  analysisStore.magTimeSeries = []
+}
+
+async function ensureLargeCachedUrl(image) {
+  if (!image.largeCachedUrl) {
+    const url = image.url || ''
+    image.largeCachedUrl = await thumbnailsStore.cacheImage('large', configStore.archiveType, url, image.basename)
+  }
+  return image.largeCachedUrl
+}
+
+function resolveImageByBasename(basename) {
+  if (!basename) return null
+
+  return props.images.find((image) => image.basename === basename) || null
+}
+
+async function loadActiveImage(image) {
+  if (!image) return
+
+  if (analysisStore.image?.basename !== image.basename) {
+    analysisStore.headerData = null
+  }
+
+  if (selectedMode.value === 'Analysis Mode') {
+    cleanupWorker()
+    resetAnalysisState()
+  }
+
+  selectedBasename.value = image.basename
+  activeImage.value = image
+  analysisStore.image = image
+
+  if (isFitsImage.value) {
+    const largeCachedUrl = await ensureLargeCachedUrl(image)
+    analysisStore.imageUrl = largeCachedUrl
+    analysisStore.loadHeaderData()
+    imgWorker = new Worker('drawImageWorker.js')
+    instantiateScalerWorker()
+  } else {
+    analysisStore.imageUrl = await ensureLargeCachedUrl(image)
+  }
+}
 
 // This function runs when imageViewer emits an analysis-action event and should be extended to handle other analysis types
 function requestAnalysis(action, input={}, action_callback=null){
   if(isFitsImage.value || action === 'get-tif' || action === 'get-jpg'){
     const url = configStore.datalabApiBaseUrl + 'analysis/' + action + '/'
     const body = {
-      'basename': props.image.basename,
-      'source': props.image.source,
+      'basename': activeImage.value.basename,
+      'source': activeImage.value.source,
       ...input
     }
     fetchApiCall({url: url, method: 'POST', body: body, successCallback: (response) => {handleAnalysisOutput(response, action, action_callback)}})
@@ -104,11 +228,11 @@ function handleAnalysisOutput(response, action, action_callback){
     break
   case 'get-tif':
     // ImageDownloadMenu.vue downloadFile()
-    action_callback(response.tif_url, props.image.basename, 'TIF')
+    action_callback(response.tif_url, activeImage.value.basename, 'TIF')
     break
   case 'get-jpg':
     // ImageDownloadMenu.vue downloadFile()
-    action_callback(response.jpg_base64, props.image.basename, 'base64')
+    action_callback(response.jpg_base64, activeImage.value.basename, 'base64')
     break
   default:
     console.error('Invalid action:', action)
@@ -156,28 +280,67 @@ function updateScaling(min, max){
   }
 }
 
+async function updateCurrentImageIndex(newIndex) {
+  const image = props.images[newIndex]
+  if (image) {
+    await loadActiveImage(image)
+  }
+}
+
+async function onModeChange(val) {
+  selectedMode.value = val
+
+  if (val === 'Analysis Mode') {
+    const image = resolveImageByBasename(selectedBasename.value) || props.image
+    await loadActiveImage(image)
+  }
+}
+
 </script>
 <template>
+  <div class="mode-dropdown-center">
+    <select
+      v-model="selectedMode"
+      class="mode-dropdown native-dropdown"
+      @change="onModeChange($event.target.value)"
+    >
+      <option value="View Mode">
+        View Mode
+      </option>
+      <option value="Analysis Mode">
+        Analysis Mode
+      </option>
+    </select>
+  </div>
   <v-sheet class="analysis-page">
     <v-toolbar
       class="analysis-toolbar"
       density="comfortable"
     >
       <filter-badge
-        v-if="image.FILTER || image.filter"
-        :filter="image.FILTER || image.filter"
+        v-if="activeImage?.FILTER || activeImage?.filter"
+        :filter="activeImage?.FILTER || activeImage?.filter"
         class="ml-2"
       />
-      <v-toolbar-title :text="image.basename || 'Unknown'" />
+      <div class="analysis-toolbar-chips">
+        <v-chip
+          v-for="chip in headerChips"
+          :key="chip.icon"
+          :prepend-icon="chip.icon"
+          color="var(--info)"
+          :text="chip.text"
+          size="small"
+        />
+      </div>
       <image-download-menu
-        :image-name="image.basename"
-        :fits-url="image.url || image.fits_url"
-        :jpg-url="image.largeCachedUrl"
+        :image-name="activeImage?.basename"
+        :fits-url="activeImage?.url || activeImage?.fits_url"
+        :jpg-url="activeImage?.largeCachedUrl"
         :enable-scaled-download="isFitsImage"
         @analysis-action="requestAnalysis"
       />
       <v-btn
-        v-if="image.id"
+        v-if="activeImage?.id"
         icon="mdi-information"
         @click="showHeaderDialog = analysisStore.loadHeaderData()"
       />
@@ -188,15 +351,55 @@ function updateScaling(min, max){
       />
     </v-toolbar>
     <v-progress-linear
-      v-hide="!analysisStore.loading"
+      v-hide="!analysisStore.loading || selectedMode !== 'View Mode'"
       rounded
       indeterminate
       stream
       color="var(--success)"
     />
-    <div class="analysis-content">
+    <div
+      v-if="selectedMode === 'View Mode' || selectedMode === ''"
+      class="analysis-content"
+    >
+      <view-mode
+        :current-index="currentImageIndex"
+        :images="props.images"
+        @update-current-index="updateCurrentImageIndex"
+      />
+      <div class="side-panel-container">
+        <v-sheet
+          class="side-panel-item"
+          rounded
+        >
+          <div class="d-flex flex-wrap ga-2 mb-4">
+            <v-chip
+              v-for="chip in headerChips"
+              :key="chip.icon"
+              :prepend-icon="chip.icon"
+              color="var(--info)"
+              :text="chip.text"
+            />
+          </div>
+          <div class="view-mode-meta">
+            <div
+              v-for="item in viewModeDetails"
+              :key="item.label"
+              class="view-mode-meta-row"
+            >
+              <span class="view-mode-meta-label">{{ item.label }}</span>
+              <span class="view-mode-meta-value">{{ item.value }}</span>
+            </div>
+          </div>
+        </v-sheet>
+      </div>
+    </div>
+    <div
+      v-else-if="selectedMode === 'Analysis Mode'"
+      class="analysis-content"
+    >
       <image-viewer
         :catalog="filteredCatalog"
+        :images="props.images"
         :wcs-solution="wcsSolution"
         @analysis-action="requestAnalysis"
       />
@@ -270,6 +473,36 @@ function updateScaling(min, max){
   </v-dialog>
 </template>
 <style scoped>
+/* Center the mode dropdown at the top */
+.mode-dropdown-center {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  width: 100%;
+  position: absolute;
+  top: 16px;
+  left: 0;
+  z-index: 2100;
+  pointer-events: none;
+}
+.mode-dropdown {
+  min-width: 120px;
+  max-width: 180px;
+  pointer-events: auto;
+}
+.native-dropdown {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--primary-interactive, #1976d2);
+  background: var(--card-background, #fff);
+  color: var(--text, #222);
+  font-size: 15px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+  outline: none;
+  appearance: none;
+  margin: 0 auto;
+  display: block;
+}
 /* Main Sections */
 .analysis-page{
   background-color: var(--primary-background);
@@ -284,11 +517,41 @@ function updateScaling(min, max){
   color: var(--text);
   background-color: var(--header);
 }
+.analysis-toolbar-chips {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  min-width: 0;
+}
 .analysis-content{
   flex: 1;
   display: flex;
   flex-direction: row;
   padding: 0.5rem;
+}
+.view-mode-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.view-mode-meta-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.view-mode-meta-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--disabled-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.view-mode-meta-value {
+  font-size: 0.98rem;
+  color: var(--text);
+  word-break: break-word;
 }
 /* Side Panel */
 .side-panel-container {

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { fetchApiCall } from '../utils/api'
-import { siteIDToName } from '@/utils/common'
+import { basenameToSequence, siteIDToName } from '@/utils/common'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAnalysisStore } from '@/stores/analysis'
 import { useUserDataStore } from '@/stores/userData'
@@ -21,14 +21,10 @@ const props = defineProps({
     type: Object,
     required: true,
     default: null,
-  },
-  images: {
-    type: Array,
-    default: () => []
   }
 })
 
-const emit = defineEmits(['closeAnalysisDialog'])
+const emit = defineEmits(['closeAnalysisDialog', 'requestPreviousImage', 'requestNextImage'])
 
 const configStore = useConfigurationStore()
 const analysisStore = useAnalysisStore()
@@ -50,14 +46,11 @@ const activeImage = ref(props.image)
 let imgWorker = new Worker('drawImageWorker.js')
 let imgWorkerProcessing = false
 let imgWorkerNextScale = null
+const touchStartX = ref(null)
 
 const selectedMode = ref('Analysis Mode')
-
-const currentImageIndex = computed(() => {
-  if (!selectedBasename.value) return -1
-  return props.images.findIndex(image => image.basename === selectedBasename.value)
-})
-
+const hasPrevious = computed(() => props.image?.hasPrevious === true)
+const hasNext = computed(() => props.image?.hasNext === true)
 
 const filteredCatalog = computed(() => {
   if (!userDataStore.catalogToggle) {
@@ -73,12 +66,7 @@ const isFitsImage = computed(() => {
   return activeImage.value && (!('type' in activeImage.value) || activeImage.value?.type === 'fits')
 })
 
-const basenameSequence = computed(() => {
-  const basename = activeImage.value?.basename || ''
-  const match = basename.match(/^[^-]+-[^-]+-[^-]+-([^-]+)-e91$/)
-
-  return match?.[1] || 'Unknown'
-})
+const basenameSequence = computed(() => basenameToSequence(activeImage.value?.basename || ''))
 
 const headerChips = computed(() => {
   const headerData = analysisStore.headerData
@@ -109,17 +97,19 @@ const viewModeDetails = computed(() => {
 })
 
 onMounted(async() => {
-  await loadActiveImage(resolveImageByBasename(selectedBasename.value) || props.image)
+  window.addEventListener('keydown', handleKeydown)
+  await loadActiveImage(props.image)
 })
 
 watch(() => props.image, async (image) => {
   if (!image?.basename) return
 
   selectedBasename.value = image.basename
-  await loadActiveImage(resolveImageByBasename(image.basename) || image)
+  await loadActiveImage(image)
 })
 
 onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
   cleanupWorker()
   analysisStore.$dispose()
   delete getActivePinia().state.value[analysisStore.$id]
@@ -156,17 +146,17 @@ function resetAnalysisState() {
 }
 
 async function ensureLargeCachedUrl(image) {
-  if (!image.largeCachedUrl) {
-    const url = image.url || ''
-    image.largeCachedUrl = await thumbnailsStore.cacheImage('large', configStore.archiveType, url, image.basename)
-  }
+  const archiveSource = image?.source && image.source !== 'archive'
+    ? image.source
+    : configStore.archiveType
+  const url = image.large_url || image.largeThumbUrl || ''
+  image.largeCachedUrl = await thumbnailsStore.cacheImage(
+    'large',
+    archiveSource,
+    url,
+    image.basename,
+  )
   return image.largeCachedUrl
-}
-
-function resolveImageByBasename(basename) {
-  if (!basename) return null
-
-  return props.images.find((image) => image.basename === basename) || null
 }
 
 async function loadActiveImage(image) {
@@ -198,6 +188,50 @@ async function loadActiveImage(image) {
 
     imgWorker = new Worker('drawImageWorker.js')
     instantiateScalerWorker()
+  }
+}
+
+function requestPreviousImage() {
+  if (hasPrevious.value) {
+    emit('requestPreviousImage')
+  }
+}
+
+function requestNextImage() {
+  if (hasNext.value) {
+    emit('requestNextImage')
+  }
+}
+
+function handleKeydown(event) {
+  if (selectedMode.value !== 'View Mode') return
+
+  if (event.key === 'ArrowLeft') {
+    requestPreviousImage()
+  } else if (event.key === 'ArrowRight') {
+    requestNextImage()
+  }
+}
+
+function handleViewTouchStart(event) {
+  touchStartX.value = event.changedTouches[0]?.clientX ?? null
+}
+
+function handleViewTouchEnd(event) {
+  if (touchStartX.value == null || selectedMode.value !== 'View Mode') {
+    return
+  }
+
+  const touchEndX = event.changedTouches[0]?.clientX ?? touchStartX.value
+  const deltaX = touchEndX - touchStartX.value
+  touchStartX.value = null
+
+  if (Math.abs(deltaX) < 40) return
+
+  if (deltaX < 0) {
+    requestNextImage()
+  } else {
+    requestPreviousImage()
   }
 }
 
@@ -291,19 +325,11 @@ function updateScaling(min, max){
   }
 }
 
-async function updateCurrentImageIndex(newIndex) {
-  const image = props.images[newIndex]
-  if (image) {
-    await loadActiveImage(image)
-  }
-}
-
 async function onModeChange(val) {
   selectedMode.value = val
 
   if (val === 'Analysis Mode') {
-    const image = resolveImageByBasename(selectedBasename.value) || props.image
-    await loadActiveImage(image)
+    await loadActiveImage(props.image)
   }
 }
 
@@ -371,11 +397,15 @@ async function onModeChange(val) {
     <div
       v-if="selectedMode === 'View Mode' || selectedMode === ''"
       class="analysis-content"
+      @touchstart.passive="handleViewTouchStart"
+      @touchend.passive="handleViewTouchEnd"
     >
       <view-mode
-        :current-index="currentImageIndex"
-        :images="props.images"
-        @update-current-index="updateCurrentImageIndex"
+        :image="activeImage"
+        :has-previous="hasPrevious"
+        :has-next="hasNext"
+        @previous="requestPreviousImage"
+        @next="requestNextImage"
       />
       <div class="side-panel-container">
         <v-sheet
@@ -410,7 +440,6 @@ async function onModeChange(val) {
     >
       <image-viewer
         :catalog="filteredCatalog"
-        :images="props.images"
         :wcs-solution="wcsSolution"
         @analysis-action="requestAnalysis"
       />

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -5,7 +5,6 @@ import { basenameToSequence, siteIDToName } from '@/utils/common'
 import { useConfigurationStore } from '@/stores/configuration'
 import { useAnalysisStore } from '@/stores/analysis'
 import { useUserDataStore } from '@/stores/userData'
-import { useThumbnailsStore } from '@/stores/thumbnails'
 import FilterBadge from '@/components/Global/FilterBadge.vue'
 import NonLinearSlider from '@/components/Global/NonLinearSlider.vue'
 import HistogramSlider from '@/components/Global/Scaling/HistogramSlider.vue'
@@ -29,7 +28,6 @@ const emit = defineEmits(['closeAnalysisDialog', 'requestPreviousImage', 'reques
 const configStore = useConfigurationStore()
 const analysisStore = useAnalysisStore()
 const userDataStore = useUserDataStore()
-const thumbnailsStore = useThumbnailsStore()
 
 const lineProfile = ref([])
 const lineProfileLength = ref()
@@ -145,20 +143,6 @@ function resetAnalysisState() {
   analysisStore.magTimeSeries = []
 }
 
-async function ensureLargeCachedUrl(image) {
-  const archiveSource = image?.source && image.source !== 'archive'
-    ? image.source
-    : configStore.archiveType
-  const url = image.large_url || image.largeThumbUrl || ''
-  image.largeCachedUrl = await thumbnailsStore.cacheImage(
-    'large',
-    archiveSource,
-    url,
-    image.basename,
-  )
-  return image.largeCachedUrl
-}
-
 async function loadActiveImage(image) {
   if (!image) return
 
@@ -176,8 +160,7 @@ async function loadActiveImage(image) {
   activeImage.value = image
   analysisStore.image = image
 
-  const largeCachedUrl = await ensureLargeCachedUrl(image)
-  analysisStore.imageUrl = largeCachedUrl
+  analysisStore.imageUrl = image.largeCachedUrl || image.large_url || image.largeThumbUrl || ''
 
   if (isFitsImage.value) {
     analysisStore.loadHeaderData()

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -176,8 +176,9 @@ async function loadActiveImage(image) {
     analysisStore.headerData = null
   }
 
+  cleanupWorker()
+
   if (selectedMode.value === 'Analysis Mode') {
-    cleanupWorker()
     resetAnalysisState()
   }
 
@@ -185,14 +186,18 @@ async function loadActiveImage(image) {
   activeImage.value = image
   analysisStore.image = image
 
+  const largeCachedUrl = await ensureLargeCachedUrl(image)
+  analysisStore.imageUrl = largeCachedUrl
+
   if (isFitsImage.value) {
-    const largeCachedUrl = await ensureLargeCachedUrl(image)
-    analysisStore.imageUrl = largeCachedUrl
     analysisStore.loadHeaderData()
+
+    if (selectedMode.value !== 'Analysis Mode') {
+      return
+    }
+
     imgWorker = new Worker('drawImageWorker.js')
     instantiateScalerWorker()
-  } else {
-    analysisStore.imageUrl = await ensureLargeCachedUrl(image)
   }
 }
 
@@ -245,6 +250,10 @@ async function instantiateScalerWorker(){
   try { await analysisStore.loadScaleData() } 
   catch (error) { return console.error('Failed to load scale data:', error) }
 
+  if (!imgWorker || !analysisStore.imageWidth || !analysisStore.imageHeight || !analysisStore.rawData?.data) {
+    return
+  }
+
   // Create a new offscreen canvas for the worker
   const imgScalingCanvas = document.createElement('canvas')
   imgScalingCanvas.width = analysisStore.imageWidth
@@ -269,14 +278,16 @@ async function instantiateScalerWorker(){
 }
 
 function updateScaling(min, max){
-  if (isFitsImage.value) {
-    imgWorkerNextScale = [min, max]
+  if (!isFitsImage.value || selectedMode.value !== 'Analysis Mode' || !imgWorker) {
+    return
+  }
 
-    if (imgWorkerNextScale && !imgWorkerProcessing){
-      imgWorkerProcessing = true
-      imgWorker.postMessage({scalePoints: [...imgWorkerNextScale]})
-      imgWorkerNextScale = null
-    }
+  imgWorkerNextScale = [min, max]
+
+  if (imgWorkerNextScale && !imgWorkerProcessing){
+    imgWorkerProcessing = true
+    imgWorker.postMessage({scalePoints: [...imgWorkerNextScale]})
+    imgWorkerNextScale = null
   }
 }
 

--- a/src/views/ImageAnalysisView.vue
+++ b/src/views/ImageAnalysisView.vue
@@ -47,8 +47,6 @@ let imgWorkerNextScale = null
 const touchStartX = ref(null)
 
 const selectedMode = ref(userDataStore.imageDisplayMode || 'Analysis Mode')
-const hasPrevious = computed(() => props.image?.hasPrevious === true)
-const hasNext = computed(() => props.image?.hasNext === true)
 
 const filteredCatalog = computed(() => {
   if (!userDataStore.catalogToggle) {
@@ -179,15 +177,11 @@ async function loadActiveImage(image) {
 }
 
 function requestPreviousImage() {
-  if (hasPrevious.value) {
-    emit('requestPreviousImage')
-  }
+  emit('requestPreviousImage')
 }
 
 function requestNextImage() {
-  if (hasNext.value) {
-    emit('requestNextImage')
-  }
+  emit('requestNextImage')
 }
 
 function handleKeydown(event) {
@@ -392,8 +386,6 @@ async function onModeChange(val) {
     >
       <view-mode
         :image="activeImage"
-        :has-previous="hasPrevious"
-        :has-next="hasNext"
         @previous="requestPreviousImage"
         @next="requestNextImage"
       />


### PR DESCRIPTION
## Feature: Slideshow

**Background:**
Rachel would like to see the movement of moons throughout a period of time. Though she would like in the future for this to be an operation where users select a number of images and the output is a video/gif/animation of them going one after the other. A happy medium in the meantime is to add previous and next buttons and sort images chronologically.

**Implementation:**
First, in Data Session View, images are now sorted chronologically. This makes the next and previous button work as intended.
There are two modes that users can view their images: Analysis mode and View mode. In analysis mode, things remain the same. The previous and next buttons are not available here because it takes a really long time to load. In view mode, the user can go back and forth and then switch back into Analysis mode to analyze the image they are currently viewing. 


### VISUALS
**Analysis mode**
<img width="1374" height="1016" alt="image" src="https://github.com/user-attachments/assets/25384324-2ce0-4a14-a9a6-3dd1481c3fb9" />

**View mode**
<img width="1367" height="908" alt="image" src="https://github.com/user-attachments/assets/9b40ec00-e0c0-4162-8346-4f76c6c5d540" />


**Screen recording**

https://github.com/user-attachments/assets/65557627-676c-404d-9205-dd896dd9ec99


UPDATED SCREEN RECORDING

https://github.com/user-attachments/assets/1ee538d8-7a56-46b0-b5ca-7981f1e0352b



