### PR TITLE
Replace polynomial fit with robust LOESS

### DIFF
--- a/src/components/Analysis/LightCurvePlot.vue
+++ b/src/components/Analysis/LightCurvePlot.vue
@@ -4,6 +4,7 @@ import 'chartjs-adapter-luxon'
 import { ref, watch, computed, defineProps, onMounted } from 'vue'
 import { downloadChartAsPNG } from '@/utils/downloadChart.js'
 import { normalizeLightCurveRows } from '@/utils/lightCurve.js'
+import { loessPoints } from '@/utils/lightCurveFit.js'
 
 const props = defineProps({
   variableStarData: {
@@ -17,7 +18,6 @@ let lightCurveChart = null
 const CHART_PADDING = 0.5
 const DECIMAL_PLACES = 4
 const ERROR_BAR_CAP_WIDTH = 8
-const POLYNOMIAL_SAMPLE_COUNT = 120
 const X_AXIS_LEFT_PADDING_RATIO = 0.05
 const MIN_X_AXIS_LEFT_PADDING_MS = 60 * 60 * 1000
 
@@ -71,8 +71,9 @@ const chartData = computed(() => {
     .filter(Number.isFinite)
   const minDate = Math.min(...dateValues)
   const maxDate = Math.max(...dateValues)
+  const magerrs = magTimeSeries.map(({ magerr }) => magerr)
   const magnitudePoints = magnitudes.map((magnitude, index) => ({ x: dateValues[index], y: magnitude }))
-  const polynomialPoints = cubicPolynomialPoints(dateValues, magnitudes, minDate, maxDate)
+  const trendPoints = loessPoints(dateValues, magnitudes, magerrs, minDate, maxDate)
   const errors = magTimeSeries.map(({ mag, magerr }) => {
     if (!Number.isFinite(magerr)) return null
     const lowerBound = Number((mag - magerr).toFixed(DECIMAL_PLACES))
@@ -80,8 +81,8 @@ const chartData = computed(() => {
     return [lowerBound, upperBound]
   })
   const errorBounds = errors.flatMap(error => error || [])
-  const polynomialMagnitudes = polynomialPoints.map(point => point.y)
-  const plotValues = [...magnitudes, ...errorBounds, ...polynomialMagnitudes]
+  const trendMagnitudes = trendPoints.map(point => point.y)
+  const plotValues = [...magnitudes, ...errorBounds, ...trendMagnitudes]
   const minMagnitude = Math.min(...plotValues)
   const maxMagnitude = Math.max(...plotValues)
   const leftTimePadding = Math.max((maxDate - minDate) * X_AXIS_LEFT_PADDING_RATIO, MIN_X_AXIS_LEFT_PADDING_MS)
@@ -91,7 +92,7 @@ const chartData = computed(() => {
     dates: dates,
     magnitudes: magnitudes,
     magnitudePoints: magnitudePoints,
-    polynomialPoints: polynomialPoints,
+    trendPoints: trendPoints,
     errors: errors,
     chartMin: minMagnitude - CHART_PADDING,
     chartMax: maxMagnitude + CHART_PADDING,
@@ -110,10 +111,10 @@ watch(() => props.variableStarData, () => {
 
 function updateChart() {
   // Set all the new data
-  const { dates, magnitudePoints, polynomialPoints, errors, chartMin, chartMax, chartMinDate } = chartData.value
+  const { dates, magnitudePoints, trendPoints, errors, chartMin, chartMax, chartMinDate } = chartData.value
   lightCurveChart.data.labels = dates
   lightCurveChart.data.datasets[0].data = magnitudePoints
-  lightCurveChart.data.datasets[1].data = polynomialPoints
+  lightCurveChart.data.datasets[1].data = trendPoints
   lightCurveChart.options.scales.x.min = chartMinDate
   lightCurveChart.options.scales.x.max = undefined
   lightCurveChart.options.plugins.lightCurveErrorBars.errors = errors
@@ -132,7 +133,7 @@ function createChart() {
   const background = style.getPropertyValue('--secondary-background')
   const info = style.getPropertyValue('--info')
 
-  const { dates, magnitudePoints, polynomialPoints, errors, chartMin, chartMax, chartMinDate } = chartData.value
+  const { dates, magnitudePoints, trendPoints, errors, chartMin, chartMax, chartMinDate } = chartData.value
   if (!magnitudePoints.length) return
 
   lightCurveChart = new Chart(lightCurveCanvas.value, {
@@ -156,8 +157,8 @@ function createChart() {
           pointHoverBackgroundColor: secondary,
         },
         {
-          label: 'Cubic Fit',
-          data: polynomialPoints,
+          label: 'LOESS Fit',
+          data: trendPoints,
           order: 1,
           borderColor: secondary,
           borderWidth: 2,
@@ -226,117 +227,6 @@ function createChart() {
       }
     }
   })
-}
-
-function cubicPolynomialPoints(dateValues, magnitudes, minDate, maxDate) {
-  const points = dateValues
-    .map((date, index) => ({ date, magnitude: magnitudes[index] }))
-    .filter(point => Number.isFinite(point.date) && Number.isFinite(point.magnitude))
-
-  if (points.length < 2 || !Number.isFinite(minDate) || !Number.isFinite(maxDate)) {
-    return []
-  }
-
-  const xSpan = maxDate - minDate || 1
-  const normalizedPoints = points.map(point => ({
-    x: (point.date - minDate) / xSpan,
-    y: point.magnitude
-  }))
-  const degree = Math.min(3, normalizedPoints.length - 1)
-  const coefficients = polynomialRegression(normalizedPoints, degree)
-  if (!coefficients) return []
-
-  const sampleCount = Math.max(POLYNOMIAL_SAMPLE_COUNT, magnitudes.length)
-  return Array.from({ length: sampleCount }, (_, sampleIndex) => {
-    const normalizedX = sampleCount === 1 ? 0 : sampleIndex / (sampleCount - 1)
-    return {
-      x: minDate + (normalizedX * xSpan),
-      y: evaluatePolynomial(coefficients, normalizedX)
-    }
-  })
-}
-
-/*
-  Fits the visible light-curve points with a least-squares polynomial.
-  The returned coefficients describe this curve:
-
-    y = a + bx + cx^2 + dx^3
-
-  Example return value:
-
-    [a, b, c, d]
-
-  The x values are normalized dates from 0 to 1 before fitting so the
-  polynomial is stable across large timestamp values. Normalized dates
-  mean each timestamp is converted relative to the visible date range:
-
-    normalizedX = (date - minDate) / (maxDate - minDate)
-
-  Example:
-
-    first date  -> 0
-    middle date -> 0.5
-    last date   -> 1
-
-  The plotted x values are still real dates. The degree is capped by the
-  available point count, so two points produce a line, three points produce
-  a quadratic, and four or more points produce a cubic.
-*/
-function polynomialRegression(points, degree) {
-  const matrix = []
-  const vector = []
-
-  for (let row = 0; row <= degree; row++) {
-    matrix[row] = []
-    for (let col = 0; col <= degree; col++) {
-      matrix[row][col] = points.reduce((sum, point) => sum + Math.pow(point.x, row + col), 0)
-    }
-    vector[row] = points.reduce((sum, point) => sum + point.y * Math.pow(point.x, row), 0)
-  }
-
-  return solveLinearSystem(matrix, vector)
-}
-
-function solveLinearSystem(matrix, vector) {
-  const size = vector.length
-  const augmented = matrix.map((row, index) => [...row, vector[index]])
-
-  for (let pivot = 0; pivot < size; pivot++) {
-    let pivotRow = pivot
-    for (let row = pivot + 1; row < size; row++) {
-      if (Math.abs(augmented[row][pivot]) > Math.abs(augmented[pivotRow][pivot])) {
-        pivotRow = row
-      }
-    }
-    if (Math.abs(augmented[pivotRow][pivot]) < Number.EPSILON) return null
-
-    if (pivotRow !== pivot) {
-      const temp = augmented[pivot]
-      augmented[pivot] = augmented[pivotRow]
-      augmented[pivotRow] = temp
-    }
-
-    const pivotValue = augmented[pivot][pivot]
-    for (let col = pivot; col <= size; col++) {
-      augmented[pivot][col] /= pivotValue
-    }
-
-    for (let row = 0; row < size; row++) {
-      if (row === pivot) continue
-      const factor = augmented[row][pivot]
-      for (let col = pivot; col <= size; col++) {
-        augmented[row][col] -= factor * augmented[pivot][col]
-      }
-    }
-  }
-
-  return augmented.map(row => row[size])
-}
-
-function evaluatePolynomial(coefficients, x) {
-  return coefficients.reduce((sum, coefficient, power) => {
-    return sum + coefficient * Math.pow(x, power)
-  }, 0)
 }
 
 onMounted(() => {

--- a/src/components/Global/CalibrationComparisonPlot.vue
+++ b/src/components/Global/CalibrationComparisonPlot.vue
@@ -1,0 +1,198 @@
+<script setup>
+import Chart from 'chart.js/auto'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  rows: {
+    type: Array,
+    default: () => []
+  },
+  target: {
+    type: Object,
+    default: null
+  },
+  title: {
+    type: String,
+    default: 'Calibration Comparison'
+  }
+})
+
+const canvas = ref(null)
+let chart = null
+
+const candidatePoints = computed(() => {
+  return props.rows
+    .map(row => ({
+      x: Number(row.calculatedMagnitude),
+      y: Number(row.calculatedFlux),
+      candidateId: row.identifier,
+    }))
+    .filter(point => Number.isFinite(point.x) && Number.isFinite(point.y))
+})
+
+const calibrationLinePoints = computed(() => {
+  const points = [...candidatePoints.value, ...targetPoints.value]
+  const validPoints = points.filter(point => Number.isFinite(point.x) && Number.isFinite(point.y) && point.y > 0)
+  if (!validPoints.length) return []
+
+  const targetPoint = targetPoints.value.find(point => Number.isFinite(point.x) && Number.isFinite(point.y) && point.y > 0)
+  const zeroPointSource = targetPoint || validPoints[0]
+  const zeroPoint = zeroPointSource.x + (2.5 * Math.log10(zeroPointSource.y))
+  const magnitudes = validPoints.map(point => point.x)
+  const minMagnitude = Math.min(...magnitudes)
+  const maxMagnitude = Math.max(...magnitudes)
+
+  return [
+    { x: minMagnitude, y: magnitudeToCounts(minMagnitude, zeroPoint) },
+    { x: maxMagnitude, y: magnitudeToCounts(maxMagnitude, zeroPoint) },
+  ]
+})
+
+const targetPoints = computed(() => {
+  const x = Number(props.target?.magnitude)
+  const y = Number(props.target?.flux)
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return []
+  return [{ x, y }]
+})
+
+function createChart() {
+  if (!canvas.value) return
+  const style = getComputedStyle(document.body)
+  const text = style.getPropertyValue('--text')
+  const primary = style.getPropertyValue('--primary-interactive')
+  const secondary = style.getPropertyValue('--secondary-interactive')
+  const background = style.getPropertyValue('--secondary-background')
+
+  chart = new Chart(canvas.value, {
+    type: 'scatter',
+    data: {
+      datasets: [
+        {
+          label: 'Calibration Relation',
+          data: calibrationLinePoints.value,
+          borderColor: primary,
+          borderWidth: 1.5,
+          backgroundColor: primary,
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          showLine: true,
+          fill: false,
+        },
+        {
+          label: 'Comparison Stars',
+          data: candidatePoints.value,
+          backgroundColor: primary,
+          borderColor: primary,
+          pointRadius: 3,
+          pointHoverRadius: 5,
+        },
+        {
+          label: 'Target',
+          data: targetPoints.value,
+          backgroundColor: secondary,
+          borderColor: secondary,
+          pointRadius: 5,
+          pointHoverRadius: 7,
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          type: 'linear',
+          title: { display: true, text: 'Calibrated Magnitude', color: text },
+          ticks: {
+            color: text,
+            callback: (value) => Number(value).toFixed(3),
+          },
+          grid: { color: background },
+          reverse: true,
+        },
+        y: {
+          type: 'logarithmic',
+          title: { display: true, text: 'Net Source Counts', color: text },
+          ticks: {
+            color: text,
+            callback: formatScientificTick,
+            maxTicksLimit: 5,
+          },
+          grid: { color: background },
+        }
+      },
+      plugins: {
+        legend: {
+          labels: { color: text }
+        },
+        tooltip: {
+          callbacks: {
+            label: (context) => {
+              const point = context.raw
+              const label = context.dataset.label
+              const name = point.candidateId ? `${point.candidateId}: ` : ''
+              return `${label} ${name}mag ${Number(point.x).toFixed(3)}, net source counts ${Number(point.y).toFixed(0)}`
+            }
+          }
+        }
+      }
+    }
+  })
+}
+
+function formatScientificTick(value) {
+  const number = Number(value)
+  if (!Number.isFinite(number) || number <= 0) return ''
+  const exponent = Math.floor(Math.log10(number))
+  let coefficient = number / Math.pow(10, exponent)
+  let adjustedExponent = exponent
+  if (coefficient >= 9.9995) {
+    coefficient = 1
+    adjustedExponent += 1
+  }
+  return `${coefficient.toFixed(3)} x 10^${adjustedExponent}`
+}
+
+function magnitudeToCounts(magnitude, zeroPoint) {
+  return 10 ** ((zeroPoint - magnitude) / 2.5)
+}
+
+function updateChart() {
+  if (!chart) {
+    nextTick(createChart)
+    return
+  }
+  chart.data.datasets[0].data = calibrationLinePoints.value
+  chart.data.datasets[1].data = candidatePoints.value
+  chart.data.datasets[2].data = targetPoints.value
+  chart.update()
+}
+
+watch(() => [props.rows, props.target], updateChart, { deep: true })
+
+onMounted(() => {
+  createChart()
+})
+
+onBeforeUnmount(() => {
+  if (chart) {
+    chart.destroy()
+    chart = null
+  }
+})
+</script>
+
+<template>
+  <div class="calibration-plot">
+    <canvas ref="canvas" />
+  </div>
+</template>
+
+<style scoped>
+.calibration-plot {
+  height: 240px;
+  min-height: 240px;
+  width: 100%;
+  margin-top: 0.75rem;
+}
+</style>

--- a/src/utils/lightCurveFit.js
+++ b/src/utils/lightCurveFit.js
@@ -1,0 +1,204 @@
+// LOESS (locally weighted regression) fit for light-curve trend overlays.
+//
+// A single global polynomial is a poor model for light curves: high enough order to
+// trace real features rings at the endpoints (Runge phenomenon), and the basis assumes
+// a shape the data may not have. LOESS instead fits each output point from only a local
+// window of nearby observations, so the curve adapts to arbitrary shapes (periodic
+// stars or one-shot transients) without ringing, weights by measurement error, and
+// resists outliers via robustness iterations.
+
+// Number of points sampled along the output trend line (for a smooth polyline).
+const LOESS_SAMPLE_COUNT = 120
+// Fraction of points in each local window; the smoothness knob (smaller = more detail).
+const LOESS_SPAN = 0.3
+// Local polynomial degree. Degree 1 (local linear) is used deliberately: a local
+// quadratic overshoots at the endpoints, reintroducing the ringing this replaces.
+const LOESS_DEGREE = 1
+// Number of robustness (outlier down-weighting) passes.
+const LOESS_ROBUST_ITERS = 2
+// Cleveland's robustness envelope: residuals beyond this many median deviations
+// (measured in error bars) are treated as outliers and fully down-weighted.
+const LOESS_ROBUST_TUNING = 6
+
+/*
+  Fits the light-curve points with LOESS to produce a smooth trend overlay.
+
+  For every sampled x we:
+    1. take the nearest LOESS_SPAN fraction of points as the window,
+    2. weight them by a tricube function of distance (near points dominate),
+    3. multiply in a measurement weight of 1/magerr^2 (precise points dominate),
+    4. fit a low-degree polynomial centered on x, so the value at x is its intercept.
+  A couple of robustness passes then down-weight outliers by how many error bars they
+  sit from the local fit.
+
+  x is normalized to [0, 1] over the visible date range before fitting for numerical
+  stability; the returned x values are still real dates. Returns [{ x, y }], or [] when
+  there are too few valid points to fit.
+*/
+export function loessPoints(dateValues, magnitudes, magerrs, minDate, maxDate) {
+  const points = dateValues
+    .map((date, index) => ({ date, magnitude: magnitudes[index], magerr: magerrs[index] }))
+    .filter(point => Number.isFinite(point.date) && Number.isFinite(point.magnitude))
+
+  if (points.length < 2 || !Number.isFinite(minDate) || !Number.isFinite(maxDate)) {
+    return []
+  }
+
+  const xSpan = maxDate - minDate || 1
+  const validErrors = points
+    .map(point => point.magerr)
+    .filter(magerr => Number.isFinite(magerr) && magerr > 0)
+  // Points with no usable error are treated as median precision rather than ignored:
+  // a flat weight of 1 would be negligible next to real 1/sigma^2 weights (often
+  // thousands), effectively dropping those points from the fit.
+  const fallbackSigma = validErrors.length ? median(validErrors) : 1
+  const normalizedPoints = points.map(point => {
+    const sigma = Number.isFinite(point.magerr) && point.magerr > 0 ? point.magerr : fallbackSigma
+    return {
+      x: (point.date - minDate) / xSpan,
+      y: point.magnitude,
+      sigma,
+      // Inverse-variance weighting: precise measurements count more.
+      weight: 1 / (sigma * sigma)
+    }
+  })
+
+  const robustnessWeights = loessRobustnessWeights(normalizedPoints)
+
+  const sampleCount = Math.max(LOESS_SAMPLE_COUNT, magnitudes.length)
+  return Array.from({ length: sampleCount }, (_, sampleIndex) => {
+    const normalizedX = sampleCount === 1 ? 0 : sampleIndex / (sampleCount - 1)
+    return {
+      x: minDate + (normalizedX * xSpan),
+      y: localRegression(normalizedPoints, robustnessWeights, normalizedX)
+    }
+  })
+}
+
+/*
+  Runs the robust LOWESS iterations: fit at each observation, then down-weight points
+  with large residuals using a bisquare function and refit. Returns one robustness
+  weight per observation, applied on top of the tricube/measurement weights.
+
+  Residuals are studentized (divided by the point's error bar) before the bisquare, so
+  outliers are judged by how many error bars they sit from the local fit: a noisy point
+  is treated leniently, a precise-but-discrepant point strictly. The median scale keeps
+  this adaptive even when the reported error bars are systematically mis-calibrated.
+*/
+function loessRobustnessWeights(points) {
+  let robustnessWeights = new Array(points.length).fill(1)
+
+  for (let iteration = 0; iteration < LOESS_ROBUST_ITERS; iteration++) {
+    const studentizedResiduals = points.map((point) =>
+      Math.abs(point.y - localRegression(points, robustnessWeights, point.x)) / point.sigma)
+    const medianResidual = median(studentizedResiduals)
+    if (!(medianResidual > 0)) break // exact or degenerate fit; nothing to down-weight
+
+    robustnessWeights = studentizedResiduals.map(residual => {
+      const scaled = residual / (LOESS_ROBUST_TUNING * medianResidual)
+      return scaled >= 1 ? 0 : Math.pow(1 - scaled * scaled, 2)
+    })
+  }
+
+  return robustnessWeights
+}
+
+/*
+  Estimates the smoothed magnitude at evalX from a local weighted polynomial fit.
+  Because the local polynomial is fitted in the coordinate (x - evalX), its value at
+  evalX is simply the intercept, so we only need the first coefficient.
+*/
+function localRegression(points, robustnessWeights, evalX) {
+  const pointCount = points.length
+  const windowSize = Math.min(pointCount, Math.max(LOESS_DEGREE + 1, Math.ceil(LOESS_SPAN * pointCount)))
+  const distances = points.map(point => Math.abs(point.x - evalX))
+  const bandwidth = [...distances].sort((a, b) => a - b)[windowSize - 1] || Number.EPSILON
+
+  const samples = []
+  for (let index = 0; index < pointCount; index++) {
+    if (distances[index] > bandwidth) continue
+    const tricube = Math.pow(1 - Math.pow(distances[index] / bandwidth, 3), 3)
+    const weight = tricube * points[index].weight * robustnessWeights[index]
+    if (weight <= 0) continue
+    samples.push({ x: points[index].x - evalX, y: points[index].y, weight })
+  }
+
+  if (!samples.length) return nearestMagnitude(points, distances)
+
+  // Drop the degree when the window has too few points to support LOESS_DEGREE.
+  const localDegree = Math.min(LOESS_DEGREE, samples.length - 1)
+  const coefficients = weightedPolyFit(samples, localDegree)
+  if (!coefficients) return nearestMagnitude(points, distances)
+
+  return coefficients[0]
+}
+
+function nearestMagnitude(points, distances) {
+  let nearestIndex = 0
+  for (let index = 1; index < distances.length; index++) {
+    if (distances[index] < distances[nearestIndex]) nearestIndex = index
+  }
+  return points[nearestIndex].y
+}
+
+/*
+  Weighted least-squares polynomial fit via the normal equations, reusing
+  solveLinearSystem. Returns coefficients [c0, c1, ...] for y = c0 + c1*x + ...
+*/
+function weightedPolyFit(samples, degree) {
+  const matrix = []
+  const vector = []
+
+  for (let row = 0; row <= degree; row++) {
+    matrix[row] = []
+    for (let col = 0; col <= degree; col++) {
+      matrix[row][col] = samples.reduce((sum, sample) => sum + sample.weight * Math.pow(sample.x, row + col), 0)
+    }
+    vector[row] = samples.reduce((sum, sample) => sum + sample.weight * sample.y * Math.pow(sample.x, row), 0)
+  }
+
+  return solveLinearSystem(matrix, vector)
+}
+
+function median(values) {
+  if (!values.length) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+function solveLinearSystem(matrix, vector) {
+  const size = vector.length
+  const augmented = matrix.map((row, index) => [...row, vector[index]])
+
+  for (let pivot = 0; pivot < size; pivot++) {
+    let pivotRow = pivot
+    for (let row = pivot + 1; row < size; row++) {
+      if (Math.abs(augmented[row][pivot]) > Math.abs(augmented[pivotRow][pivot])) {
+        pivotRow = row
+      }
+    }
+    if (Math.abs(augmented[pivotRow][pivot]) < Number.EPSILON) return null
+
+    if (pivotRow !== pivot) {
+      const temp = augmented[pivot]
+      augmented[pivot] = augmented[pivotRow]
+      augmented[pivotRow] = temp
+    }
+
+    const pivotValue = augmented[pivot][pivot]
+    for (let col = pivot; col <= size; col++) {
+      augmented[pivot][col] /= pivotValue
+    }
+
+    for (let row = 0; row < size; row++) {
+      if (row === pivot) continue
+      const factor = augmented[row][pivot]
+      for (let col = pivot; col <= size; col++) {
+        augmented[row][col] -= factor * augmented[pivot][col]
+      }
+    }
+  }
+
+  return augmented.map(row => row[size])
+}


### PR DESCRIPTION
The trend overlay in `LightCurvePlot` was a single global least-squares polynomial (cubic, degree capped at 3). That's not the best model for light curves because:

- It rings. Any order high enough to trace real features oscillates near the endpoints.
- Hard to fit all light curves: Light curves can be periodic or transients  like supernovae. No low-order global polynomial fits both well.

LOESS takes a different approach. Each output point is fitted from only a local window of nearby observations, so the curve adapts to arbitrary shapes without ringing.

The approach taken here was:

- Local linear (degree 1), span 0.3: linear fitting is deliberate. Even a local quadratic can overshoot at the boundaries, reintroducing the ringing this replaces. Note that this doesn't mean we draw straight lines between points. We break the interval into multiple x samples and fit at each point.
- Inverse-variance weighting (`1/magerr²`): so precise measurements count more.
- Robustness passes: down-weight outliers by studentized residuals, i.e. how many error bars a point sits from the local fit, so a noisy point is treated leniently and a precise but discrepant point strictly.

The math(s) is extracted to a pure, importable module (`src/utils/lightCurveFit.js`, exporting `loessPoints`) so `LightCurvePlot.vue` shrinks to chart wiring only. The trend dataset label changes `Cubic Fit` → `LOESS Fit`. 

**Testing**
The repo doesn't currently have a test runner, so verification was numeric checks run against the extracted module directly: confirmed no endpoint ringing on supernova rise/fall type and noisy-sinusoidal data, outliers rejected and degenerate / missing-error inputs handled. `node --check` passes on both files.