### PR TITLE
Allow clicking to expand and diagnostic images to full resolution and…

### DIFF
--- a/src/components/Global/DataOutput.vue
+++ b/src/components/Global/DataOutput.vue
@@ -31,6 +31,7 @@ const lightCurveSparkline = computed(() => {
 })
 
 const diagnosticsDialog = ref(false)
+const expandedDiagnosticImage = ref(null)
 
 const diagnosticSections = computed(() => {
   return Object.entries(props.operationOutput?.diagnostics || {}).map(([fileName, sectionDiagnostics]) => {
@@ -314,6 +315,8 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
                       :alt="`${section.fileName} candidate star overlay`"
                       crossorigin="anonymous"
                       class="diagnostic-overlay-image"
+                      title="Click to view at full resolution"
+                      @click.stop="expandedDiagnosticImage = { url: section.diagnosticImage, fileName: section.fileName }"
                     >
                   </div>
                   <calibration-comparison-plot
@@ -353,6 +356,39 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
             @click="diagnosticsDialog = false"
           />
         </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <v-dialog
+      :model-value="expandedDiagnosticImage !== null"
+      fullscreen
+      @update:model-value="expandedDiagnosticImage = null"
+    >
+      <v-card
+        color="var(--card-background)"
+        class="expanded-image-card"
+        :ripple="false"
+        @click="expandedDiagnosticImage = null"
+      >
+        <v-card-title class="expanded-image-title">
+          <span class="diagnostics-file-title">{{ expandedDiagnosticImage?.fileName }}</span>
+          <v-spacer />
+          <v-btn
+            icon="mdi-close"
+            variant="text"
+            density="compact"
+            title="Close"
+            @click="expandedDiagnosticImage = null"
+          />
+        </v-card-title>
+        <v-card-text class="expanded-image-viewport">
+          <img
+            v-if="expandedDiagnosticImage"
+            :src="expandedDiagnosticImage.url"
+            :alt="`${expandedDiagnosticImage.fileName} candidate star overlay at full resolution`"
+            crossorigin="anonymous"
+            class="expanded-image"
+          >
+        </v-card-text>
       </v-card>
     </v-dialog>
   </v-sheet>
@@ -424,6 +460,32 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
   margin: 0 auto;
   border-radius: 8px;
   background: #000;
+  cursor: zoom-in;
+}
+
+/* Anywhere on the expanded view closes it, so the whole surface shows the zoom-out cursor. */
+.expanded-image-card {
+  cursor: zoom-out;
+}
+
+.expanded-image-title {
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Fills the dialog under the title bar and scrolls when the overlay is wider or taller
+   than the window, since the image inside is drawn at its native pixel size. */
+.expanded-image-viewport {
+  height: calc(100vh - 64px);
+  overflow: auto;
+  background: #000;
+}
+
+.expanded-image {
+  display: block;
+  margin: 0 auto;
 }
 
 .diagnostics-table :deep(th) {


### PR DESCRIPTION
… click again to shrink back. The attached video was pre resolution bump in the backend so it should be a little less pixelated then what this shows when full screen.


https://github.com/user-attachments/assets/8df4df2e-ccbb-4d54-b500-428b85f9e1a7

