### PR TITLE
Refactor the diagnostics view to take separate vue files per output t…

### DIFF
--- a/src/components/Global/DataOutput.vue
+++ b/src/components/Global/DataOutput.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { computed, ref } from 'vue'
 import FilterBadge from './FilterBadge.vue'
-import CalibrationComparisonPlot from '@/components/Global/CalibrationComparisonPlot.vue'
-import { lightCurveMagnitudes, normalizeLightCurveRows } from '@/utils/lightCurve.js'
+import { diagnosticsViewFor } from '@/components/Global/diagnostics'
+import { lightCurveMagnitudes } from '@/utils/lightCurve.js'
 
 const props = defineProps({
   operationOutput: {
@@ -31,109 +31,10 @@ const lightCurveSparkline = computed(() => {
 })
 
 const diagnosticsDialog = ref(false)
-const expandedDiagnosticImage = ref(null)
 
-const diagnosticSections = computed(() => {
-  return Object.entries(props.operationOutput?.diagnostics || {}).map(([fileName, sectionDiagnostics]) => {
-    return buildDiagnosticSection(fileName, sectionDiagnostics)
-  })
-})
-
-const hasDiagnostics = computed(() => {
-  return diagnosticSections.value.some(section => {
-    return section.rows.length || section.notes.length || section.diagnosticImage
-  })
-})
-
-const normalizedLightCurveRows = computed(() => normalizeLightCurveRows(props.operationOutput?.light_curve))
-
-function buildDiagnosticSection(fileName, sectionDiagnostics) {
-  const rows = sectionDiagnostics
-    .filter(diagnostic => typeof diagnostic === 'string' && diagnostic.startsWith('comparison-star validation row:'))
-    .map(parseComparisonValidationRow)
-    .filter(Boolean)
-
-  const notes = sectionDiagnostics.filter(diagnostic => {
-    if (typeof diagnostic !== 'string') return true
-    return !diagnostic.startsWith('comparison-star validation row:') &&
-      !diagnostic.startsWith('comparison star identifier |')
-  })
-
-  return {
-    fileName,
-    rows,
-    notes,
-    target: targetForFile(fileName),
-    diagnosticImage: diagnosticImageForFile(fileName),
-  }
-}
-
-function diagnosticImageForFile(fileName) {
-  const images = props.operationOutput?.diagnostic_images
-  if (!images || Array.isArray(images) || typeof images !== 'object') return null
-
-  const imageUrl = images[fileName] || Object.entries(images).find(([imageFileName]) => {
-    return fitsPathMatches(imageFileName, fileName)
-  })?.[1]
-  return imageUrl || null
-}
-
-function targetForFile(fileName) {
-  const lightCurveRow = normalizedLightCurveRows.value.find(row => fitsPathMatches(row.fits_path, fileName))
-  if (!lightCurveRow) return null
-  return {
-    magnitude: lightCurveRow.mag,
-    flux: lightCurveRow.target_net_source_counts,
-  }
-}
-
-function fitsPathMatches(fitsPath, fileName) {
-  if (!fitsPath || !fileName) return false
-  const fitsText = String(fitsPath)
-  const fileText = String(fileName)
-  return fitsText === fileText || fitsText.endsWith(fileText) || fileText.endsWith(fitsText.split('/').pop())
-}
-
-function parseComparisonValidationRow(diagnostic) {
-  const rowText = diagnostic.replace('comparison-star validation row:', '').trim()
-  const fields = rowText.split('|').map(field => field.trim())
-  if (fields.length !== 7) return null
-
-  return {
-    identifier: fields[0],
-    ra: fields[1],
-    dec: fields[2],
-    calculatedFlux: fields[3],
-    catalogFlux: fields[4],
-    calculatedMagnitude: fields[5],
-    catalogMagnitude: fields[6],
-  }
-}
-
-function formatDiagnosticTitle(diagnostic) {
-  if (diagnostic === null || diagnostic === undefined) return 'No diagnostic detail'
-  if (typeof diagnostic === 'string') return diagnostic
-  if (typeof diagnostic !== 'object') return String(diagnostic)
-  return diagnostic.message || diagnostic.title || diagnostic.name || 'Diagnostic'
-}
-
-function formatDiagnosticDetails(diagnostic) {
-  if (!diagnostic || typeof diagnostic !== 'object') return ''
-  return Object.entries(diagnostic)
-    .filter(([key]) => !['message', 'title', 'name'].includes(key))
-    .map(([key, value]) => `${formatDiagnosticKey(key)}: ${formatDiagnosticValue(value)}`)
-    .join('\n')
-}
-
-function formatDiagnosticKey(key) {
-  return key.replaceAll('_', ' ')
-}
-
-function formatDiagnosticValue(value) {
-  if (value === null || value === undefined) return 'N/A'
-  if (typeof value === 'object') return JSON.stringify(value)
-  return String(value)
-}
+// The diagnostics dialog is a generic shell; its body comes from whichever component the
+// operation that produced this output registered in components/Global/diagnostics.
+const diagnosticsView = computed(() => diagnosticsViewFor(props.operationOutput))
 
 const periodogramSparkline = computed(() => {
   if (props.operationOutput.power) {
@@ -234,7 +135,7 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
         {{ title }}
       </p>
       <v-icon
-        v-if="hasDiagnostics"
+        v-if="diagnosticsView"
         icon="mdi-information-outline"
         color="var(--info)"
         title="View diagnostics"
@@ -247,132 +148,19 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
       />
     </div>
     <v-dialog
+      v-if="diagnosticsView"
       v-model="diagnosticsDialog"
-      max-width="920"
+      max-width="1200"
     >
       <v-card color="var(--card-background)">
         <v-card-title class="diagnostics-title">
-          Diagnostics
+          {{ props.operationOutput.operationName }} Diagnostics
         </v-card-title>
         <v-card-text>
-          <v-expansion-panels
-            variant="accordion"
-            class="diagnostics-panels"
-          >
-            <v-expansion-panel
-              v-for="section in diagnosticSections"
-              :key="section.fileName"
-              class="diagnostics-panel"
-            >
-              <v-expansion-panel-title>
-                <span class="diagnostics-file-title">{{ section.fileName }}</span>
-              </v-expansion-panel-title>
-              <v-expansion-panel-text>
-                <section
-                  v-if="section.rows.length"
-                  class="diagnostics-section"
-                >
-                  <h3 class="diagnostics-section-title">
-                    Comparison Star Validation
-                  </h3>
-                  <v-table
-                    density="compact"
-                    class="diagnostics-table"
-                  >
-                    <thead>
-                      <tr>
-                        <th>Candidate ID</th>
-                        <th class="numeric-column">
-                          RA
-                        </th>
-                        <th class="numeric-column">
-                          Dec
-                        </th>
-                        <th class="numeric-column">
-                          Flux
-                        </th>
-                        <th class="numeric-column">
-                          Catalog Flux
-                        </th>
-                        <th class="numeric-column">
-                          Mag
-                        </th>
-                        <th class="numeric-column">
-                          Catalog Mag
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr
-                        v-for="row in section.rows"
-                        :key="section.fileName + '-' + row.identifier"
-                      >
-                        <td>{{ row.identifier }}</td>
-                        <td class="numeric-column">
-                          {{ row.ra }}
-                        </td>
-                        <td class="numeric-column">
-                          {{ row.dec }}
-                        </td>
-                        <td class="numeric-column">
-                          {{ row.calculatedFlux }}
-                        </td>
-                        <td class="numeric-column">
-                          {{ row.catalogFlux }}
-                        </td>
-                        <td class="numeric-column">
-                          {{ row.calculatedMagnitude }}
-                        </td>
-                        <td class="numeric-column">
-                          {{ row.catalogMagnitude }}
-                        </td>
-                      </tr>
-                    </tbody>
-                  </v-table>
-                  <div
-                    v-if="section.diagnosticImage"
-                    class="diagnostic-overlay"
-                  >
-                    <h3 class="diagnostics-section-title">
-                      Candidate Star Overlay
-                    </h3>
-                    <img
-                      :src="section.diagnosticImage"
-                      :alt="`${section.fileName} candidate star overlay`"
-                      crossorigin="anonymous"
-                      class="diagnostic-overlay-image"
-                      title="Click to view at full resolution"
-                      @click.stop="expandedDiagnosticImage = { url: section.diagnosticImage, fileName: section.fileName }"
-                    >
-                  </div>
-                  <calibration-comparison-plot
-                    :rows="section.rows"
-                    :target="section.target"
-                  />
-                </section>
-                <section
-                  v-if="section.notes.length"
-                  class="diagnostics-section"
-                >
-                  <h3 class="diagnostics-section-title">
-                    Notes
-                  </h3>
-                  <v-list
-                    density="compact"
-                    bg-color="transparent"
-                  >
-                    <v-list-item
-                      v-for="(diagnostic, index) in section.notes"
-                      :key="index"
-                      :title="formatDiagnosticTitle(diagnostic)"
-                      :subtitle="formatDiagnosticDetails(diagnostic)"
-                      class="diagnostic-item"
-                    />
-                  </v-list>
-                </section>
-              </v-expansion-panel-text>
-            </v-expansion-panel>
-          </v-expansion-panels>
+          <component
+            :is="diagnosticsView"
+            :operation-output="props.operationOutput"
+          />
         </v-card-text>
         <v-card-actions>
           <v-spacer />
@@ -382,39 +170,6 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
             @click="diagnosticsDialog = false"
           />
         </v-card-actions>
-      </v-card>
-    </v-dialog>
-    <v-dialog
-      :model-value="expandedDiagnosticImage !== null"
-      fullscreen
-      @update:model-value="expandedDiagnosticImage = null"
-    >
-      <v-card
-        color="var(--card-background)"
-        class="expanded-image-card"
-        :ripple="false"
-        @click="expandedDiagnosticImage = null"
-      >
-        <v-card-title class="expanded-image-title">
-          <span class="diagnostics-file-title">{{ expandedDiagnosticImage?.fileName }}</span>
-          <v-spacer />
-          <v-btn
-            icon="mdi-close"
-            variant="text"
-            density="compact"
-            title="Close"
-            @click="expandedDiagnosticImage = null"
-          />
-        </v-card-title>
-        <v-card-text class="expanded-image-viewport">
-          <img
-            v-if="expandedDiagnosticImage"
-            :src="expandedDiagnosticImage.url"
-            :alt="`${expandedDiagnosticImage.fileName} candidate star overlay at full resolution`"
-            crossorigin="anonymous"
-            class="expanded-image"
-          >
-        </v-card-text>
       </v-card>
     </v-dialog>
   </v-sheet>
@@ -454,106 +209,6 @@ const emit = defineEmits(['selectOperationOutput', 'launchAnalysis', 'removeOper
 
 .diagnostics-title {
   color: var(--text);
-}
-
-.diagnostics-section {
-  margin-bottom: 1rem;
-}
-
-.diagnostics-panels {
-  background: transparent;
-}
-
-.diagnostics-panel {
-  background-color: var(--secondary-background);
-  color: var(--text);
-}
-
-.diagnostics-file-title {
-  color: var(--text);
-  font-family: monospace;
-  font-size: 0.85rem;
-}
-
-.diagnostics-section-title {
-  color: var(--text);
-  font-family: var(--font-stack);
-  font-size: 0.95rem;
-  font-weight: 700;
-  margin: 0 0 0.5rem;
-  text-transform: none;
-}
-
-.diagnostics-table {
-  background-color: var(--secondary-background);
-  color: var(--text);
-  border-radius: 8px;
-  overflow: hidden;
-}
-
-.diagnostic-overlay {
-  margin-top: 1rem;
-}
-
-.diagnostic-overlay-image {
-  display: block;
-  max-width: 100%;
-  max-height: 360px;
-  margin: 0 auto;
-  border-radius: 8px;
-  background: #000;
-  cursor: zoom-in;
-}
-
-/* Anywhere on the expanded view closes it, so the whole surface shows the zoom-out cursor. */
-.expanded-image-card {
-  cursor: zoom-out;
-}
-
-.expanded-image-title {
-  color: var(--text);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-/* Fills the dialog under the title bar and scrolls when the overlay is wider or taller
-   than the window, since the image inside is drawn at its native pixel size. */
-.expanded-image-viewport {
-  height: calc(100vh - 64px);
-  overflow: auto;
-  background: #000;
-}
-
-.expanded-image {
-  display: block;
-  margin: 0 auto;
-}
-
-.diagnostics-table :deep(th) {
-  color: var(--text);
-  font-size: 0.75rem;
-  font-weight: 700;
-  white-space: nowrap;
-  text-align: center !important;
-  vertical-align: middle;
-}
-
-.diagnostics-table :deep(td) {
-  color: var(--text);
-  font-family: monospace;
-  font-size: 0.8rem;
-  white-space: nowrap;
-  text-align: center;
-  vertical-align: middle;
-}
-
-.numeric-column {
-  text-align: center;
-}
-
-.diagnostic-item {
-  white-space: pre-line;
 }
 
 .annotated-output {

--- a/src/components/Global/TitledCard.vue
+++ b/src/components/Global/TitledCard.vue
@@ -1,0 +1,66 @@
+<script setup>
+
+/*
+  An outlined card whose title sits on top of the outline in the upper left corner, fieldset
+  legend style. The title paints its own background so it interrupts the border line it
+  overlaps - that background has to match whatever the card is sitting on, so it is a prop
+  defaulting to the page background. The card contents are templated out to the caller.
+*/
+
+defineProps({
+  title: {
+    type: String,
+    required: true
+  },
+  // background behind the title text, matched to the surface the card sits on so the
+  // outline reads as broken rather than struck through
+  titleBackground: {
+    type: String,
+    default: 'var(--primary-background)'
+  }
+})
+
+</script>
+<template>
+  <v-card
+    variant="outlined"
+    class="titled-card"
+  >
+    <v-card-title
+      class="titled-card-title"
+      :style="{ backgroundColor: titleBackground }"
+    >
+      {{ title }}
+    </v-card-title>
+    <v-card-text class="titled-card-text">
+      <slot />
+    </v-card-text>
+  </v-card>
+</template>
+
+<style scoped>
+.titled-card {
+  overflow: visible;
+  margin-top: 0.75rem;
+  border-color: color-mix(in srgb, var(--text) 25%, transparent);
+}
+
+.titled-card-title {
+  position: absolute;
+  top: 0;
+  left: 0.75rem;
+  transform: translateY(-50%);
+  padding: 0 0.5rem;
+  color: var(--text);
+  font-family: var(--font-stack);
+  font-size: 1.2rem;
+  font-weight: bold;
+  line-height: 1.2;
+  text-transform: none;
+}
+
+.titled-card-text {
+  color: var(--text);
+  padding-top: 1rem;
+}
+</style>

--- a/src/components/Global/diagnostics/AperturePhotometryDiagnostics.vue
+++ b/src/components/Global/diagnostics/AperturePhotometryDiagnostics.vue
@@ -1,0 +1,366 @@
+<script setup>
+import { computed, ref } from 'vue'
+import CalibrationComparisonPlot from '@/components/Global/CalibrationComparisonPlot.vue'
+import { normalizeLightCurveRows } from '@/utils/lightCurve.js'
+
+const VALIDATION_ROW_PREFIX = 'comparison-star validation row:'
+const VALIDATION_HEADER_PREFIX = 'comparison star identifier |'
+
+const props = defineProps({
+  operationOutput: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+const expandedDiagnosticImage = ref(null)
+
+const normalizedLightCurveRows = computed(() => normalizeLightCurveRows(props.operationOutput?.light_curve))
+
+// Turns the backend's `diagnostics` map (keyed by FITS basename) into one section per file,
+// splitting the comparison-star validation rows out of the free-form notes and pairing each
+// file with its overlay image and its light curve row.
+const diagnosticSections = computed(() => {
+  return Object.entries(props.operationOutput?.diagnostics || {}).map(([fileName, sectionDiagnostics]) => {
+    const rows = sectionDiagnostics
+      .filter(diagnostic => typeof diagnostic === 'string' && diagnostic.startsWith(VALIDATION_ROW_PREFIX))
+      .map(parseComparisonValidationRow)
+      .filter(Boolean)
+
+    const notes = sectionDiagnostics.filter(diagnostic => {
+      if (typeof diagnostic !== 'string') return true
+      return !diagnostic.startsWith(VALIDATION_ROW_PREFIX) && !diagnostic.startsWith(VALIDATION_HEADER_PREFIX)
+    })
+
+    return {
+      fileName,
+      rows,
+      notes,
+      target: targetForFile(fileName),
+      diagnosticImage: diagnosticImageForFile(fileName),
+    }
+  })
+})
+
+function diagnosticImageForFile(fileName) {
+  const images = props.operationOutput?.diagnostic_images
+  if (!images || Array.isArray(images) || typeof images !== 'object') return null
+
+  const imageUrl = images[fileName] || Object.entries(images).find(([imageFileName]) => {
+    return fitsPathMatches(imageFileName, fileName)
+  })?.[1]
+  return imageUrl || null
+}
+
+function targetForFile(fileName) {
+  const lightCurveRow = normalizedLightCurveRows.value.find(row => fitsPathMatches(row.fits_path, fileName))
+  if (!lightCurveRow) return null
+  return {
+    magnitude: lightCurveRow.mag,
+    flux: lightCurveRow.target_net_source_counts,
+  }
+}
+
+function fitsPathMatches(fitsPath, fileName) {
+  if (!fitsPath || !fileName) return false
+  const fitsText = String(fitsPath)
+  const fileText = String(fileName)
+  return fitsText === fileText || fitsText.endsWith(fileText) || fileText.endsWith(fitsText.split('/').pop())
+}
+
+function parseComparisonValidationRow(diagnostic) {
+  const rowText = diagnostic.replace(VALIDATION_ROW_PREFIX, '').trim()
+  const fields = rowText.split('|').map(field => field.trim())
+  if (fields.length !== 7) return null
+
+  return {
+    identifier: fields[0],
+    ra: fields[1],
+    dec: fields[2],
+    calculatedFlux: fields[3],
+    catalogFlux: fields[4],
+    calculatedMagnitude: fields[5],
+    catalogMagnitude: fields[6],
+  }
+}
+
+function formatDiagnosticTitle(diagnostic) {
+  if (diagnostic === null || diagnostic === undefined) return 'No diagnostic detail'
+  if (typeof diagnostic === 'string') return diagnostic
+  if (typeof diagnostic !== 'object') return String(diagnostic)
+  return diagnostic.message || diagnostic.title || diagnostic.name || 'Diagnostic'
+}
+
+function formatDiagnosticDetails(diagnostic) {
+  if (!diagnostic || typeof diagnostic !== 'object') return ''
+  return Object.entries(diagnostic)
+    .filter(([key]) => !['message', 'title', 'name'].includes(key))
+    .map(([key, value]) => `${formatDiagnosticKey(key)}: ${formatDiagnosticValue(value)}`)
+    .join('\n')
+}
+
+function formatDiagnosticKey(key) {
+  return key.replaceAll('_', ' ')
+}
+
+function formatDiagnosticValue(value) {
+  if (value === null || value === undefined) return 'N/A'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+</script>
+<template>
+  <v-expansion-panels
+    variant="accordion"
+    class="diagnostics-panels"
+  >
+    <v-expansion-panel
+      v-for="section in diagnosticSections"
+      :key="section.fileName"
+      class="diagnostics-panel"
+    >
+      <v-expansion-panel-title>
+        <span class="diagnostics-file-title">{{ section.fileName }}</span>
+      </v-expansion-panel-title>
+      <v-expansion-panel-text>
+        <section
+          v-if="section.rows.length"
+          class="diagnostics-section"
+        >
+          <h3 class="diagnostics-section-title">
+            Comparison Star Validation
+          </h3>
+          <v-table
+            density="compact"
+            class="diagnostics-table"
+          >
+            <thead>
+              <tr>
+                <th>Candidate ID</th>
+                <th class="numeric-column">
+                  RA
+                </th>
+                <th class="numeric-column">
+                  Dec
+                </th>
+                <th class="numeric-column">
+                  Flux
+                </th>
+                <th class="numeric-column">
+                  Catalog Flux
+                </th>
+                <th class="numeric-column">
+                  Mag
+                </th>
+                <th class="numeric-column">
+                  Catalog Mag
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="row in section.rows"
+                :key="section.fileName + '-' + row.identifier"
+              >
+                <td>{{ row.identifier }}</td>
+                <td class="numeric-column">
+                  {{ row.ra }}
+                </td>
+                <td class="numeric-column">
+                  {{ row.dec }}
+                </td>
+                <td class="numeric-column">
+                  {{ row.calculatedFlux }}
+                </td>
+                <td class="numeric-column">
+                  {{ row.catalogFlux }}
+                </td>
+                <td class="numeric-column">
+                  {{ row.calculatedMagnitude }}
+                </td>
+                <td class="numeric-column">
+                  {{ row.catalogMagnitude }}
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+          <div
+            v-if="section.diagnosticImage"
+            class="diagnostic-overlay"
+          >
+            <h3 class="diagnostics-section-title">
+              Candidate Star Overlay
+            </h3>
+            <img
+              :src="section.diagnosticImage"
+              :alt="`${section.fileName} candidate star overlay`"
+              crossorigin="anonymous"
+              class="diagnostic-overlay-image"
+              title="Click to view at full resolution"
+              @click.stop="expandedDiagnosticImage = { url: section.diagnosticImage, fileName: section.fileName }"
+            >
+          </div>
+          <calibration-comparison-plot
+            :rows="section.rows"
+            :target="section.target"
+          />
+        </section>
+        <section
+          v-if="section.notes.length"
+          class="diagnostics-section"
+        >
+          <h3 class="diagnostics-section-title">
+            Notes
+          </h3>
+          <v-list
+            density="compact"
+            bg-color="transparent"
+          >
+            <v-list-item
+              v-for="(diagnostic, index) in section.notes"
+              :key="index"
+              :title="formatDiagnosticTitle(diagnostic)"
+              :subtitle="formatDiagnosticDetails(diagnostic)"
+              class="diagnostic-item"
+            />
+          </v-list>
+        </section>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+  </v-expansion-panels>
+  <v-dialog
+    :model-value="expandedDiagnosticImage !== null"
+    fullscreen
+    @update:model-value="expandedDiagnosticImage = null"
+  >
+    <v-card
+      color="var(--card-background)"
+      class="expanded-image-card"
+      :ripple="false"
+      @click="expandedDiagnosticImage = null"
+    >
+      <v-card-title class="expanded-image-title">
+        <span class="diagnostics-file-title">{{ expandedDiagnosticImage?.fileName }}</span>
+        <v-spacer />
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          density="compact"
+          title="Close"
+          @click="expandedDiagnosticImage = null"
+        />
+      </v-card-title>
+      <v-card-text class="expanded-image-viewport">
+        <img
+          v-if="expandedDiagnosticImage"
+          :src="expandedDiagnosticImage.url"
+          :alt="`${expandedDiagnosticImage.fileName} candidate star overlay at full resolution`"
+          crossorigin="anonymous"
+          class="expanded-image"
+        >
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style scoped>
+.diagnostics-section {
+  margin-bottom: 1rem;
+}
+
+.diagnostics-panels {
+  background: transparent;
+}
+
+.diagnostics-panel {
+  background-color: var(--secondary-background);
+  color: var(--text);
+}
+
+.diagnostics-file-title {
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.diagnostics-section-title {
+  color: var(--text);
+  font-family: var(--font-stack);
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  text-transform: none;
+}
+
+.diagnostics-table {
+  background-color: var(--secondary-background);
+  color: var(--text);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.diagnostic-overlay {
+  margin-top: 1rem;
+}
+
+.diagnostic-overlay-image {
+  display: block;
+  max-width: 100%;
+  max-height: 360px;
+  margin: 0 auto;
+  border-radius: 8px;
+  background: #000;
+  cursor: zoom-in;
+}
+
+/* Anywhere on the expanded view closes it, so the whole surface shows the zoom-out cursor. */
+.expanded-image-card {
+  cursor: zoom-out;
+}
+
+.expanded-image-title {
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Fills the dialog under the title bar and scrolls when the overlay is wider or taller
+   than the window, since the image inside is drawn at its native pixel size. */
+.expanded-image-viewport {
+  height: calc(100vh - 64px);
+  overflow: auto;
+  background: #000;
+}
+
+.expanded-image {
+  display: block;
+  margin: 0 auto;
+}
+
+.diagnostics-table :deep(th) {
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+  text-align: center !important;
+  vertical-align: middle;
+}
+
+.diagnostics-table :deep(td) {
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.numeric-column {
+  text-align: center;
+}
+
+.diagnostic-item {
+  white-space: pre-line;
+}
+</style>

--- a/src/components/Global/diagnostics/AperturePhotometryDiagnostics.vue
+++ b/src/components/Global/diagnostics/AperturePhotometryDiagnostics.vue
@@ -23,12 +23,10 @@ const normalizedLightCurveRows = computed(() => normalizeLightCurveRows(props.op
 const diagnosticSections = computed(() => {
   return Object.entries(props.operationOutput?.diagnostics || {}).map(([fileName, sectionDiagnostics]) => {
     const rows = sectionDiagnostics
-      .filter(diagnostic => typeof diagnostic === 'string' && diagnostic.startsWith(VALIDATION_ROW_PREFIX))
+      .filter(diagnostic => diagnostic.startsWith(VALIDATION_ROW_PREFIX))
       .map(parseComparisonValidationRow)
-      .filter(Boolean)
 
     const notes = sectionDiagnostics.filter(diagnostic => {
-      if (typeof diagnostic !== 'string') return true
       return !diagnostic.startsWith(VALIDATION_ROW_PREFIX) && !diagnostic.startsWith(VALIDATION_HEADER_PREFIX)
     })
 
@@ -43,13 +41,12 @@ const diagnosticSections = computed(() => {
 })
 
 function diagnosticImageForFile(fileName) {
-  const images = props.operationOutput?.diagnostic_images
-  if (!images || Array.isArray(images) || typeof images !== 'object') return null
+  const images = props.operationOutput?.diagnostic_images || {}
+  if (images[fileName]) return images[fileName]
 
-  const imageUrl = images[fileName] || Object.entries(images).find(([imageFileName]) => {
-    return fitsPathMatches(imageFileName, fileName)
-  })?.[1]
-  return imageUrl || null
+  // Fall back to a fuzzy filename match if we didn't find the exact filename
+  const matchedFileName = Object.keys(images).find(imageFileName => fitsPathMatches(imageFileName, fileName))
+  return images[matchedFileName] || null
 }
 
 function targetForFile(fileName) {
@@ -71,7 +68,6 @@ function fitsPathMatches(fitsPath, fileName) {
 function parseComparisonValidationRow(diagnostic) {
   const rowText = diagnostic.replace(VALIDATION_ROW_PREFIX, '').trim()
   const fields = rowText.split('|').map(field => field.trim())
-  if (fields.length !== 7) return null
 
   return {
     identifier: fields[0],
@@ -82,31 +78,6 @@ function parseComparisonValidationRow(diagnostic) {
     calculatedMagnitude: fields[5],
     catalogMagnitude: fields[6],
   }
-}
-
-function formatDiagnosticTitle(diagnostic) {
-  if (diagnostic === null || diagnostic === undefined) return 'No diagnostic detail'
-  if (typeof diagnostic === 'string') return diagnostic
-  if (typeof diagnostic !== 'object') return String(diagnostic)
-  return diagnostic.message || diagnostic.title || diagnostic.name || 'Diagnostic'
-}
-
-function formatDiagnosticDetails(diagnostic) {
-  if (!diagnostic || typeof diagnostic !== 'object') return ''
-  return Object.entries(diagnostic)
-    .filter(([key]) => !['message', 'title', 'name'].includes(key))
-    .map(([key, value]) => `${formatDiagnosticKey(key)}: ${formatDiagnosticValue(value)}`)
-    .join('\n')
-}
-
-function formatDiagnosticKey(key) {
-  return key.replaceAll('_', ' ')
-}
-
-function formatDiagnosticValue(value) {
-  if (value === null || value === undefined) return 'N/A'
-  if (typeof value === 'object') return JSON.stringify(value)
-  return String(value)
 }
 </script>
 <template>
@@ -219,8 +190,7 @@ function formatDiagnosticValue(value) {
             <v-list-item
               v-for="(diagnostic, index) in section.notes"
               :key="index"
-              :title="formatDiagnosticTitle(diagnostic)"
-              :subtitle="formatDiagnosticDetails(diagnostic)"
+              :title="diagnostic"
               class="diagnostic-item"
             />
           </v-list>

--- a/src/components/Global/diagnostics/HRDiagramDiagnostics.vue
+++ b/src/components/Global/diagnostics/HRDiagramDiagnostics.vue
@@ -1,0 +1,367 @@
+<script setup>
+import { computed, ref } from 'vue'
+import FilterBadge from '@/components/Global/FilterBadge.vue'
+import TitledCard from '@/components/Global/TitledCard.vue'
+
+/*
+  Diagnostics for an HR Diagram (color-magnitude diagram) operation output: the inputs and
+  star counts that produced the CMD, and a table of all the CMD Stars and their properties.
+*/
+
+const props = defineProps({
+  operationOutput: {
+    type: Object,
+    default: () => ({})
+  }
+})
+
+// Options for the origin of each star, which can be in the input images, gaia, or both.
+const SOURCE_FILTERS = [
+  { title: 'All stars', value: 'all' },
+  { title: 'Image + Gaia', value: 'image-gaia' },
+  { title: 'Image only', value: 'image' },
+  { title: 'Gaia only', value: 'gaia' },
+]
+
+const search = ref('')
+const sourceFilter = ref('all')
+
+const cluster = computed(() => props.operationOutput?.cluster || {})
+const membershipGuess = computed(() => props.operationOutput?.membership_guess || null)
+
+const clusterDetails = computed(() => [
+  { label: 'Cluster', value: cluster.value.name || 'Unnamed' },
+  { label: 'Center RA', value: formatNumber(cluster.value.ra, 6, '°') },
+  { label: 'Center Dec', value: formatNumber(cluster.value.dec, 6, '°') },
+  { label: 'Search Radius', value: formatNumber(cluster.value.radius_arcmin, 2, ' arcmin') },
+])
+
+const starCounts = computed(() => [
+  { label: 'Stars Found', value: props.operationOutput?.n_stars },
+  { label: 'Stars Matched', value: props.operationOutput?.n_stars_matched },
+  { label: 'Matched to Gaia', value: props.operationOutput?.n_gaia_matched },
+  { label: 'Gaia Only', value: props.operationOutput?.n_gaia_only },
+])
+
+const membershipDetails = computed(() => {
+  const guess = membershipGuess.value
+  if (!guess) return []
+  return [
+    { label: 'pmRA Center', value: formatNumber(guess.pmra, 3, ' mas/yr') },
+    { label: 'pmDec Center', value: formatNumber(guess.pmdec, 3, ' mas/yr') },
+    { label: 'pm Radius', value: formatNumber(guess.pm_radius, 3, ' mas/yr') },
+    { label: 'Parallax Range', value: formatRange(guess.parallax_min, guess.parallax_max, 3, ' mas') },
+    { label: 'Distance Range', value: formatRange(guess.distance_min, guess.distance_max, 0, ' pc') },
+  ]
+})
+
+const blueFilter = computed(() => props.operationOutput?.blue_filter || '')
+const redFilter = computed(() => props.operationOutput?.red_filter || '')
+
+const tableHeaders = computed(() => [
+  { title: 'Source', key: 'source' },
+  { title: 'RA', key: 'ra', align: 'center' },
+  { title: 'Dec', key: 'dec', align: 'center' },
+  { title: colorTitle.value, key: 'color', align: 'center' },
+  { title: magTitle.value, key: 'mag', align: 'center' },
+  { title: 'pmRA (mas/yr)', key: 'pmra', align: 'center' },
+  { title: 'pmDec (mas/yr)', key: 'pmdec', align: 'center' },
+  { title: 'Distance (pc)', key: 'distance', align: 'center' },
+  { title: 'Parallax (mas)', key: 'parallax', align: 'center' },
+])
+
+const colorTitle = computed(() => {
+  return blueFilter.value && redFilter.value ? `Color (${blueFilter.value} - ${redFilter.value})` : 'Color'
+})
+
+const magTitle = computed(() => {
+  const band = props.operationOutput?.mag_band || redFilter.value
+  return band ? `Mag (${band})` : 'Mag'
+})
+
+// `source` is materialized onto each row rather than computed in the template so that the
+// table can sort, filter, and search on it like any other column
+const tableItems = computed(() => {
+  return (props.operationOutput?.cmd || []).map(star => ({
+    ...star,
+    source: sourceLabel(star),
+  }))
+})
+
+const filteredItems = computed(() => {
+  if (sourceFilter.value === 'all') return tableItems.value
+  return tableItems.value.filter(star => sourceValue(star) === sourceFilter.value)
+})
+
+function sourceValue(star) {
+  if (star.gaia_only) return 'gaia'
+  return star.gaia_match ? 'image-gaia' : 'image'
+}
+
+function sourceLabel(star) {
+  return SOURCE_FILTERS.find(filter => filter.value === sourceValue(star))?.title || ''
+}
+
+function formatNumber(value, digits = 3, suffix = '') {
+  if (value === null || value === undefined || !Number.isFinite(Number(value))) return '—'
+  return `${Number(value).toFixed(digits)}${suffix}`
+}
+
+// value ± uncertainty, collapsing to just the value when the error is missing
+function formatMeasurement(value, error, digits = 3) {
+  if (value === null || value === undefined || !Number.isFinite(Number(value))) return '—'
+  const formattedValue = Number(value).toFixed(digits)
+  if (error === null || error === undefined || !Number.isFinite(Number(error))) return formattedValue
+  return `${formattedValue} ± ${Number(error).toFixed(digits)}`
+}
+
+function formatRange(minimum, maximum, digits = 3, suffix = '') {
+  if (minimum === null || minimum === undefined || maximum === null || maximum === undefined) return '—'
+  return `${Number(minimum).toFixed(digits)} – ${Number(maximum).toFixed(digits)}${suffix}`
+}
+
+// the Bailer-Jones distance carries asymmetric 16th/84th percentile bounds rather than an error
+function formatDistance(star) {
+  if (star.distance === null || star.distance === undefined) return '—'
+  const distance = Number(star.distance).toFixed(0)
+  if (star.distance_lo === null || star.distance_lo === undefined ||
+    star.distance_hi === null || star.distance_hi === undefined) {
+    return distance
+  }
+  return `${distance} (${Number(star.distance_lo).toFixed(0)} – ${Number(star.distance_hi).toFixed(0)})`
+}
+</script>
+<template>
+  <section class="diagnostics-section">
+    <titled-card
+      title="Cluster"
+      title-background="var(--card-background)"
+    >
+      <div class="summary-grid divided-grid">
+        <div
+          v-for="detail in clusterDetails"
+          :key="detail.label"
+          class="summary-item"
+        >
+          <span class="summary-label">{{ detail.label }}</span>
+          <span class="summary-value">{{ detail.value }}</span>
+        </div>
+        <div class="summary-item">
+          <span class="summary-label">Filters</span>
+          <span class="summary-value d-flex ga-1">
+            <filter-badge
+              v-if="blueFilter"
+              :filter="blueFilter"
+            />
+            <filter-badge
+              v-if="redFilter"
+              :filter="redFilter"
+            />
+          </span>
+        </div>
+      </div>
+    </titled-card>
+  </section>
+  <section class="diagnostics-section">
+    <titled-card
+      title="Stars"
+      title-background="var(--card-background)"
+    >
+      <div class="summary-grid divided-grid">
+        <div
+          v-for="count in starCounts"
+          :key="count.label"
+          class="summary-item"
+        >
+          <span class="summary-label">{{ count.label }}</span>
+          <span class="summary-value">{{ count.value ?? '—' }}</span>
+        </div>
+      </div>
+    </titled-card>
+  </section>
+  <section class="diagnostics-section">
+    <titled-card
+      title="Membership Guess"
+      title-background="var(--card-background)"
+    >
+      <div
+        v-if="membershipDetails.length"
+        class="summary-grid divided-grid"
+      >
+        <div
+          v-for="detail in membershipDetails"
+          :key="detail.label"
+          class="summary-item"
+        >
+          <span class="summary-label">{{ detail.label }}</span>
+          <span class="summary-value">{{ detail.value }}</span>
+        </div>
+      </div>
+      <p
+        v-else
+        class="summary-empty"
+      >
+        No membership guess — too few Gaia matches or no clear proper-motion clump, so the
+        selection has to be made by hand in the analysis view.
+      </p>
+    </titled-card>
+  </section>
+  <section class="diagnostics-section">
+    <titled-card
+      title="Color-Magnitude Diagram Stars"
+      title-background="var(--card-background)"
+    >
+      <div class="table-controls">
+        <v-text-field
+          v-model="search"
+          variant="solo-filled"
+          bg-color="var(--primary-background)"
+          prepend-inner-icon="mdi-magnify"
+          label="Search stars"
+          density="compact"
+          hide-details
+          single-line
+        />
+        <v-select
+          v-model="sourceFilter"
+          :items="SOURCE_FILTERS"
+          variant="solo-filled"
+          bg-color="var(--primary-background)"
+          label="Star source"
+          density="compact"
+          hide-details
+        />
+      </div>
+      <v-data-table
+        v-model:search="search"
+        :headers="tableHeaders"
+        :items="filteredItems"
+        :items-per-page="10"
+        :items-per-page-options="[10, 25, 50, 100]"
+        class="diagnostics-table"
+        multi-sort
+        striped="odd"
+      >
+        <template #[`item.ra`]="{ item }">
+          {{ formatNumber(item.ra, 6) }}
+        </template>
+        <template #[`item.dec`]="{ item }">
+          {{ formatNumber(item.dec, 6) }}
+        </template>
+        <template #[`item.color`]="{ item }">
+          {{ formatMeasurement(item.color, item.color_err, 3) }}
+        </template>
+        <template #[`item.mag`]="{ item }">
+          {{ formatMeasurement(item.mag, item.magerr, 3) }}
+        </template>
+        <template #[`item.g_mag`]="{ item }">
+          {{ formatNumber(item.g_mag, 3) }}
+        </template>
+        <template #[`item.pmra`]="{ item }">
+          {{ formatMeasurement(item.pmra, item.pmra_err, 3) }}
+        </template>
+        <template #[`item.pmdec`]="{ item }">
+          {{ formatMeasurement(item.pmdec, item.pmdec_err, 3) }}
+        </template>
+        <template #[`item.parallax`]="{ item }">
+          {{ formatMeasurement(item.parallax, item.parallax_err, 3) }}
+        </template>
+        <template #[`item.distance`]="{ item }">
+          {{ formatDistance(item) }}
+        </template>
+      </v-data-table>
+    </titled-card>
+  </section>
+</template>
+
+<style scoped>
+.diagnostics-section {
+  margin-bottom: 1.5rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.5rem;
+}
+
+.summary-item {
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.divided-grid .summary-item {
+  align-items: center;
+  position: relative;
+  text-align: center;
+}
+
+.divided-grid .summary-item:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: -0.25rem;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 60%;
+  background-color: var(--text);
+  opacity: 0.25;
+}
+
+.summary-label {
+  color: var(--text);
+  font-size: 0.7rem;
+  opacity: 0.7;
+  text-transform: uppercase;
+}
+
+.summary-value {
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.9rem;
+}
+
+.summary-empty {
+  color: var(--text);
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.table-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.table-controls :deep(.v-select) {
+  max-width: 12rem;
+}
+
+.diagnostics-table {
+  background-color: var(--primary-background);
+  border-radius: 8px;
+  color: var(--text);
+  overflow: hidden;
+}
+
+.diagnostics-table :deep(th) {
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.diagnostics-table :deep(td) {
+  color: var(--text);
+  font-family: monospace;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.diagnostics-table :deep(.v-divider) {
+  margin: 0;
+}
+</style>

--- a/src/components/Global/diagnostics/index.js
+++ b/src/components/Global/diagnostics/index.js
@@ -1,0 +1,18 @@
+import AperturePhotometryDiagnostics from '@/components/Global/diagnostics/AperturePhotometryDiagnostics.vue'
+import HRDiagramDiagnostics from '@/components/Global/diagnostics/HRDiagramDiagnostics.vue'
+
+// Diagnostics are operation specific: each operation lays its own out however it wants.
+// Entries are keyed by the operation name the backend reports (DataOperation.name()).
+//
+// To add diagnostics for a new operation, write a <Operation>Diagnostics.vue in this
+// directory taking an `operationOutput` prop, and register it below.
+const DIAGNOSTICS_VIEWS = {
+  'Aperture Photometry': AperturePhotometryDiagnostics,
+  'HR Diagram': HRDiagramDiagnostics,
+}
+
+function diagnosticsViewFor(operationOutput) {
+  return DIAGNOSTICS_VIEWS[operationOutput?.operationName] || null
+}
+
+export { diagnosticsViewFor }


### PR DESCRIPTION
…hat has diagnostics, so the views can be operation output specific

First I moved all the Aperture Photometry diagnostic specific code from `DataOutput.vue` to `diagnostics/AperturePhotometryDiagnostics.vue`. Then created a new `diagnostics/HRDiagramDiagnostics.vue` for the HR Diagram Output.


https://github.com/user-attachments/assets/310662c5-4489-49bc-999b-54ec970c5aab

